### PR TITLE
Updating QDK version to 1801.1707

### DIFF
--- a/LibraryTests/LibraryTests.csproj
+++ b/LibraryTests/LibraryTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
@@ -43,33 +43,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Xunit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Xunit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.XUnit, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Xunit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.XUnit.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.XUnit, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Xunit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.XUnit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -116,6 +109,7 @@
     <QsharpCompile Include="MeasurementTests.qs" />
     <QsharpCompile Include="ApplyMultiControlledTests.qs" />
     <QsharpCompile Include="EnumerationTests.qs" />
+    <None Include="app.config" />
     <None Include="packages.config" />
     <QsharpCompile Include="QcvvTests.qs" />
     <QsharpCompile Include="AssertTests.qs" />
@@ -174,9 +168,9 @@
     <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
   <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
-  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/LibraryTests/app.config
+++ b/LibraryTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Quantum.Simulation.Core" publicKeyToken="40866b40fd95c7f5" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.1.1801.1707" newVersion="0.1.1801.1707" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/LibraryTests/packages.config
+++ b/LibraryTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
-  <package id="Microsoft.Quantum.Xunit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Xunit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />

--- a/Microsoft.Quantum.Canon/Microsoft.Quantum.Canon.csproj
+++ b/Microsoft.Quantum.Canon/Microsoft.Quantum.Canon.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,29 +54,23 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -162,10 +156,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Microsoft.Quantum.Canon/packages.config
+++ b/Microsoft.Quantum.Canon/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/AdiabaticIsing/AdiabaticIsingSample.csproj
+++ b/Samples/AdiabaticIsing/AdiabaticIsingSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,29 +36,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -95,10 +89,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/AdiabaticIsing/packages.config
+++ b/Samples/AdiabaticIsing/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/BitFlipCode/BitFlipCode.csproj
+++ b/Samples/BitFlipCode/BitFlipCode.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,29 +35,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -90,12 +84,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/BitFlipCode/packages.config
+++ b/Samples/BitFlipCode/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/DatabaseSearch/DatabaseSearchSample.csproj
+++ b/Samples/DatabaseSearch/DatabaseSearchSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,29 +56,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -111,10 +105,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/DatabaseSearch/packages.config
+++ b/Samples/DatabaseSearch/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/H2SimulationCmdLine/H2SimulationSampleCmdLine.csproj
+++ b/Samples/H2SimulationCmdLine/H2SimulationSampleCmdLine.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,29 +38,23 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -92,12 +86,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/H2SimulationCmdLine/packages.config
+++ b/Samples/H2SimulationCmdLine/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/H2SimulationGUI/H2SimulationSampleGUI.fsproj
+++ b/Samples/H2SimulationGUI/H2SimulationSampleGUI.fsproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -71,30 +71,30 @@
       <HintPath>..\..\packages\FSharp.Control.AsyncSeq.2.0.16\lib\net45\FSharp.Control.AsyncSeq.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core, Version=4.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData" />
+    <Reference Include="Microsoft.Quantum.Primitives">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives" />
+    <Reference Include="Microsoft.Quantum.Simulation.Common">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common" />
+    <Reference Include="Microsoft.Quantum.Simulation.Core">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core" />
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime" />
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators" />
     <Reference Include="mscorlib" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -124,10 +124,10 @@
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/H2SimulationGUI/packages.config
+++ b/Samples/H2SimulationGUI/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="FSharp.Charting" version="0.91.1" targetFramework="net461" />
   <package id="FSharp.Control.AsyncSeq" version="2.0.16" targetFramework="net461" />
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/HubbardSimulation/HubbardSimulationSample.csproj
+++ b/Samples/HubbardSimulation/HubbardSimulationSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -71,29 +71,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -138,10 +132,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/HubbardSimulation/packages.config
+++ b/Samples/HubbardSimulation/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/IntegerFactorization/IntegerFactorization.csproj
+++ b/Samples/IntegerFactorization/IntegerFactorization.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,29 +37,23 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -92,10 +86,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/IntegerFactorization/packages.config
+++ b/Samples/IntegerFactorization/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/IsingGenerators/IsingGeneratorsSample.csproj
+++ b/Samples/IsingGenerators/IsingGeneratorsSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,29 +56,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -111,10 +105,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/IsingGenerators/packages.config
+++ b/Samples/IsingGenerators/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/IsingPhaseEstimation/IsingPhaseEstimationSample.csproj
+++ b/Samples/IsingPhaseEstimation/IsingPhaseEstimationSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,29 +56,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -121,10 +115,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/IsingPhaseEstimation/packages.config
+++ b/Samples/IsingPhaseEstimation/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/IsingTrotterEvolution/IsingTrotterSample.csproj
+++ b/Samples/IsingTrotterEvolution/IsingTrotterSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -55,29 +55,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -110,10 +104,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/IsingTrotterEvolution/packages.config
+++ b/Samples/IsingTrotterEvolution/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/Measurement/Measurement.csproj
+++ b/Samples/Measurement/Measurement.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,29 +35,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -90,12 +84,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/Measurement/packages.config
+++ b/Samples/Measurement/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/PhaseEstimation/PhaseEstimationSample.csproj
+++ b/Samples/PhaseEstimation/PhaseEstimationSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -54,29 +54,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -109,10 +103,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/PhaseEstimation/packages.config
+++ b/Samples/PhaseEstimation/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/SimpleAlgorithms/SimpleAlgorithms.csproj
+++ b/Samples/SimpleAlgorithms/SimpleAlgorithms.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,29 +35,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -88,12 +82,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/SimpleAlgorithms/packages.config
+++ b/Samples/SimpleAlgorithms/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/SimpleIsing/SimpleIsingSample.csproj
+++ b/Samples/SimpleIsing/SimpleIsingSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -71,29 +71,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -132,10 +126,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/SimpleIsing/packages.config
+++ b/Samples/SimpleIsing/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/Teleportation/TeleportationSample.csproj
+++ b/Samples/Teleportation/TeleportationSample.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -55,29 +55,23 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -110,10 +104,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/Teleportation/packages.config
+++ b/Samples/Teleportation/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/Samples/UnitTesting/UnitTesting.csproj
+++ b/Samples/UnitTesting/UnitTesting.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" />
   <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,33 +34,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.MetaData, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.MetaData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Primitives, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Common, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Xunit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Core, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Xunit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.Simulators, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.Simulators.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Quantum.Simulation.XUnit, Version=0.1.1712.901, Culture=neutral, PublicKeyToken=40866b40fd95c7f5">
-      <HintPath>..\..\packages\Microsoft.Quantum.Xunit.0.1.1712.901-preview\lib\net461\Microsoft.Quantum.Simulation.XUnit.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Quantum.Simulation.XUnit, Version=0.1.1801.1707, Culture=neutral, PublicKeyToken=40866b40fd95c7f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Quantum.Xunit.0.1.1801.1707-preview\lib\net461\Microsoft.Quantum.Simulation.XUnit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -112,6 +105,7 @@
     <QsharpCompile Include="MultiControlledNOTTests.qs" />
     <QsharpCompile Include="MultiTargetCNOT.qs" />
     <QsharpCompile Include="MultiTargetCNOTTests.qs" />
+    <None Include="app.config" />
     <None Include="packages.config" />
     <QsharpCompile Include="TeleportationTests.qs" />
     <None Include="README.md" />
@@ -132,9 +126,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
-  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1712.901-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
+  <Import Project="..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets" Condition="Exists('..\..\packages\Microsoft.Quantum.Development.Kit.0.1.1801.1707-preview\build\Microsoft.Quantum.Development.Kit.targets')" />
 </Project>

--- a/Samples/UnitTesting/app.config
+++ b/Samples/UnitTesting/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Quantum.Simulation.Core" publicKeyToken="40866b40fd95c7f5" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.1.1801.1707" newVersion="0.1.1801.1707" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Samples/UnitTesting/packages.config
+++ b/Samples/UnitTesting/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1712.901-preview" targetFramework="net461" />
-  <package id="Microsoft.Quantum.Xunit" version="0.1.1712.901-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Development.Kit" version="0.1.1801.1707-preview" targetFramework="net461" />
+  <package id="Microsoft.Quantum.Xunit" version="0.1.1801.1707-preview" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />


### PR DESCRIPTION
Updating to new Quantum Development Kit that includes fixes for:

- The simulator now works with older CPUs that do not support AVX. It will use AVX if the CPU supports it.
- Regional decimal settings will not cause the Q# compiler to fail.
- The `SignD` primitive operation has been changed to return `Int` rather than `Double`.


