### PR TITLE
Implements transformation-based synthesis in Q#

### DIFF
--- a/LibraryTests/LibraryTests.csproj
+++ b/LibraryTests/LibraryTests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\Samples\IsingPhaseEstimation\IsingPhaseEstimationSample.csproj" />
     <ProjectReference Include="..\Samples\Measurement\Measurement.csproj" />
     <ProjectReference Include="..\Samples\PhaseEstimation\PhaseEstimationSample.csproj" />
+    <ProjectReference Include="..\Samples\ReversibleLogicSynthesis\ReversibleLogicSynthesis.csproj" />
     <ProjectReference Include="..\Samples\SimpleAlgorithms\SimpleAlgorithms.csproj" />
   </ItemGroup>
 

--- a/LibraryTests/Samples/ReversibleLogicSynthesisTests.qs
+++ b/LibraryTests/Samples/ReversibleLogicSynthesisTests.qs
@@ -1,0 +1,82 @@
+// Author: Mathias Soeken, EPFL (Mail: mathias.soeken@epfl.ch)
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Tests {
+  open Microsoft.Quantum.Canon;
+  open Microsoft.Quantum.Primitive;
+  open Microsoft.Quantum.Samples.ReversibleLogicSynthesis;
+
+  operation IsBitSetTest() : () {
+    body {
+      AssertBoolEqual(IsBitSet(10, 0), false, "0th bit should not be set in 10");
+      AssertBoolEqual(IsBitSet(10, 1), true, "1st bit should be set in 10");
+      AssertBoolEqual(IsBitSet(10, 2), false, "2nd bit should not be set in 10");
+      AssertBoolEqual(IsBitSet(10, 3), true, "3rd bit should be set in 10");
+      AssertBoolEqual(IsBitSet(10, 4), false, "4th bit should not be set in 10");
+    }
+  }
+
+  operation SequenceTest() : () {
+    body {
+      let b = 37;
+      let e = 73;
+      let s = Sequence(b, e);
+
+      for (i in 0..e - b) {
+        AssertIntEqual(s[i], b + i, $"Unexpected value in range at index {i}");
+      }
+    }
+  }
+
+  operation NumbersTest() : () {
+    body {
+      let numbers = Numbers(23);
+      AssertIntEqual(Length(numbers), 23, "Unexpected length of numbers array");
+
+      for (i in 0..22) {
+        AssertIntEqual(numbers[i], i, $"Wrong number at index ${i}");
+      }
+    }
+  }
+
+  operation IntegerBitsTest() : () {
+    body {
+      let bits = IntegerBits(10, 4);
+      AssertIntEqual(Length(bits), 2, "Wrong number of bits in number 10");
+      AssertIntEqual(bits[0], 1, "1st bit should be at position 1");
+      AssertIntEqual(bits[1], 3, "2nd bit should be at position 3");
+    }
+  }
+
+  operation SimulatePermutation(perm : Int[]) : Bool {
+    body {
+      mutable result = true;
+      let nbits = BitSize(Length(perm));
+
+      for (i in 0..Length(perm) - 1) {
+        using (qubits = Qubit[nbits]) {
+          let init = BoolArrFromPositiveInt(i, nbits);
+          ApplyPauliFromBitString(PauliX, true, init, qubits);
+          PermutationOracle(perm, qubits, TBS);
+          let simres = MeasureInteger(LittleEndian(qubits));
+          if (simres != perm[i]) {
+            set result = false;
+          }
+        }
+      }
+
+      return result;
+    }
+  }
+
+  operation TBSTest() : () {
+    body {
+      AssertBoolEqual(SimulatePermutation([0; 1; 3; 5; 7; 2; 4; 6]), true, "Simulation with TBS failed");
+      AssertBoolEqual(SimulatePermutation([0; 1; 2; 3; 4; 5; 6; 7]), true, "Simulation with TBS failed");
+      AssertBoolEqual(SimulatePermutation([7; 6; 5; 4; 3; 2; 1; 0]), true, "Simulation with TBS failed");
+      AssertBoolEqual(SimulatePermutation([0; 3; 2; 1]), true, "Simulation with TBS failed");
+      AssertBoolEqual(SimulatePermutation([0; 2; 4; 6; 8; 10; 12; 14; 1; 3; 5; 7; 9; 11; 13; 15]), true, "Simulation with TBS failed");
+    }
+  }
+}
+

--- a/Microsoft.Quantum.Canon/Combinators/Bind.qs
+++ b/Microsoft.Quantum.Canon/Combinators/Bind.qs
@@ -53,12 +53,15 @@ namespace Microsoft.Quantum.Canon {
     /// - @"microsoft.quantum.canon.binda"
     operation BindAImpl<'T>(operations : ('T => () : Adjoint)[], target : 'T) : () {
         body {
-            BindImpl(operations, target);
+            for (idxOperation in 0..Length(operations) - 1) {
+                let op = operations[idxOperation];
+                op(target);
+            }
         }
         adjoint {
             // TODO: replace with an implementation based on Reversed : 'T[] -> 'T[]
             //       and AdjointAll : ('T => () : Adjointable)[] -> ('T => () : Adjointable).
-            for (idxOperation in Length(operations) - 1..0) {
+            for (idxOperation in Length(operations) - 1..-1..0) {
                 let op = (Adjoint operations[idxOperation]);
                 op(target);
             }

--- a/Samples/ReversibleLogicSynthesis/Driver.cs
+++ b/Samples/ReversibleLogicSynthesis/Driver.cs
@@ -1,0 +1,26 @@
+// Author: Mathias Soeken, EPFL (Mail: mathias.soeken@epfl.ch)
+// Licensed under the MIT License.
+
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Microsoft.Quantum.Samples.ReversibleLogicSynthesis
+{
+    class Driver
+    {
+        static void Main(string[] args)
+        {
+            var sim = new QuantumSimulator();
+
+            QArray<long> perm = new QArray<long> { 0, 2, 3, 5, 7, 1, 4, 6 };
+            var res = PermutationSimulation.Run(sim, perm).Result;
+            System.Console.WriteLine($"Does circuit realize permutation: {res}");
+
+            for (var shift = 0; shift < perm.Length; ++shift)
+            {
+                var measured_shift = HiddenShiftProblem.Run(sim, perm, shift).Result;
+                System.Console.WriteLine($"Applied shift = {shift}   Measured shift: {measured_shift}");
+            }
+        }
+    }
+}

--- a/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.csproj
+++ b/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <StartupObject>Microsoft.Quantum.Samples.ReversibleLogicSynthesis.Driver</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Quantum.Canon\Microsoft.Quantum.Canon.csproj" />
+  </ItemGroup>
+    
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.2.1802.2202-preview" />
+  </ItemGroup>
+</Project>

--- a/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
+++ b/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
@@ -7,298 +7,298 @@ namespace Microsoft.Quantum.Samples.ReversibleLogicSynthesis {
 
     // Some helper functions
 
-	// # Summary
-	// Checks whether bit at position is set in value
-	//
-	// # Note
-	// Implementation with right-shift did not work
-	function IsBitSet(value : Int, position : Int) : Bool {
-		return (value &&& 2^position) == 2^position;
-	}
-
-	// # Summary
-	// Get an array of integers in a given interval
-	function Sequence(from : Int, to : Int) : Int[] {
-		let n = to - from + 1;
-		mutable array = new Int[n];
-		for (i in 0..n - 1) {
-			set array[i] = from + i;
-		}
-		return array;
-	}
-	
-	// # Summary
-	// Get a sequence of numbers starting from 0
-	function Numbers(count : Int) : Int[] {
-		mutable array = new Int[count];
-		for (i in 0..count - 1) {
-			set array[i] = i;
-		}
-		return array;
-	}
+    // # Summary
+    // Checks whether bit at position is set in value
+    //
+    // # Note
+    // Implementation with right-shift did not work
+    function IsBitSet(value : Int, position : Int) : Bool {
+        return (value &&& 2^position) == 2^position;
+    }
 
     // # Summary
-	// Returns all position in which bits of an integer are set
-	function IntegerBits(value : Int, length : Int) : Int[] {
-		return Filter(IsBitSet(value, _), Numbers(length));
-	}
+    // Get an array of integers in a given interval
+    function Sequence(from : Int, to : Int) : Int[] {
+        let n = to - from + 1;
+        mutable array = new Int[n];
+        for (i in 0..n - 1) {
+            set array[i] = from + i;
+        }
+        return array;
+    }
+    
+    // # Summary
+    // Get a sequence of numbers starting from 0
+    function Numbers(count : Int) : Int[] {
+        mutable array = new Int[count];
+        for (i in 0..count - 1) {
+            set array[i] = i;
+        }
+        return array;
+    }
 
-	////////////////////////////////////////////////////////////
-	// Transformation-based synthesis                         //
-	////////////////////////////////////////////////////////////
-
-	// # Summary
-	// A type to represent a multiple-controlled multiple-target Toffoli gate
-	//
-	// The first integer is a bit mask for control lines.  Bit indexes which
-	// are set correspond to control line indexes.
-	//
-	// The second integer is a bit mask for target lines.  Bit indexes which
-	// are set correspond to target line indexes.
-	//
-	// The bit indexes of both integers must be disjoint.
-	newtype MCMTMask = (Int, Int);
-
-	// # Summary
-	// A type to represent a multiple-controlled Toffoli gate
-	//
-	// The first value is an array of qubits for the control lines, the second value
-	// is a qubit for the target line.
-	//
-	// The target cannot be contained in the control lines.
-	newtype MCTGate = (Qubit[], Qubit);
-
-	// # Summary
-	// Constructs a MCMTMask type as a singleton array if targets is not 0,
-	// otherwise returns an empty array
-	function MakeGateMask(controls: Int, targets: Int) : MCMTMask[] {
-		if (targets != 0) {
-			return [MCMTMask(controls, targets)];
-		} else {
-			return new MCMTMask[0];
-		}
-	}
-
-	// # Summary
-	// Computes up to two MCMT masks to transform y to x
-	function GateMasksForAssignment(x : Int, y : Int) : MCMTMask[] {
-		let m01 = x &&& ~~~y;
-		let m10 = y &&& ~~~x;
-
-		return MakeGateMask(y, m01) + MakeGateMask(x, m10);
-	}
-
-	// # Summary
-	// Update an output pattern according to gate mask
-	function UpdateOutputPattern(pattern : Int, gateMask : MCMTMask) : Int {
-		let (controls, targets) = gateMask;
-		if ( ( pattern &&& controls ) == controls ) {
-			return pattern ^^^ targets;
-		} else {
-			return pattern;
-		}
-	}
-
-	// # Summary
-	// Update permutation based according to gate mask
-	function UpdatePermutation(perm : Int[], gateMask: MCMTMask) : Int[] {
-		return Map(UpdateOutputPattern(_, gateMask), perm);
-	}
-
-	// # Summary
-	// Computes gate masks to transform perm[x] to x and updates the current permutation
-	function TBSStep(state : (Int[], MCMTMask[]), x : Int) : (Int[], MCMTMask[]) {
-	    let (perm, gates) = state;
-		let y = perm[x];
-		let masks = GateMasksForAssignment(x, y);
-		let new_perm = Fold(UpdatePermutation, perm, masks);
-		return (new_perm, gates + masks);
-	}
-
-	// # Summary
-	// Compute gate masks to synthesize permutation
-	function TBSMain(perm : Int[]) : MCMTMask[] {
-		let xs = Numbers(Length(perm));
-		let gates = new MCMTMask[0];
-		return Reverse(Snd(Fold(TBSStep, (perm, gates), xs)));
-	}
-
-	// # Summary
-	// Translate MCT masks into multiple-controlled Toffoli gates (with single targets)
-	function GateMasksToToffoliGates(qubits : Qubit[], masks : MCMTMask[]) : MCTGate[] {
-		mutable result = new MCTGate[0];
-		let n = Length(qubits); 
-
-		for (i in 0..Length(masks) - 1) {
-			let (controls, targets) = masks[i];
-			let controlBits = IntegerBits(controls, n);
-			let targetBits = IntegerBits(targets, n);
-			let cQubits = Subarray(controlBits, qubits);
-			let tQubits = Subarray(targetBits, qubits);
-			for (t in 0..Length(tQubits) - 1) {
-				set result = result + [MCTGate(cQubits, tQubits[t])];
-			}
-		}
-
-		return result;
-	}
-
-	// # Summary
-	// Transformation-based synthesis algorithm
-	//
-	// This procedure implements the unidirectional transformation based
-	// synthesis approach.  Input is a permutation π over 2^𝑛 elements {0, ...,
-	// 2^𝑛-1}, which represents an 𝑛-variable reversible Boolean function.  The
-	// algorithm performs iteratively the following steps:
-	//
-	// 1. Find smallest 𝑥 such that 𝑥 ≠ π(𝑥) = 𝑦
-	// 2. Find multiple-controlled Toffoli gates, which applied to the outputs
-	//    make π(𝑥) = 𝑥 and do not change π(𝑥') for all 𝑥' < 𝑥
-	//
-	// # Input
-	// ## perm
-	// A permutation of 2^𝑛 elements starting from 0
-	// ## qubits
-	// A list of 𝑛 qubits where the Toffoli gates are being applied to.  Note
-	// that the algorithm does not apply the gates.  But only prepares the
-	// Toffoli gates.  The function should be called as argument to the function
-	// PermutationOracle.
-	//
-	// # Output
-	// ## A list of multiple-controlled Toffoli gates
-	//
-	// # References
-    // - [*D. Michael Miller*, *Dmitri Maslov*, *Gerhard W. Dueck*,
-    //    Proc. DAC 2003, IEEE, pp. 318-323, 2003](https://doi.org/10.1145/775832.775915)
-	// - [*Mathias Soeken*, *Gerhard W. Dueck*, *D. Michael Miller*,
-    //    Proc. RC 2016, Springer, pp. 307-321, 2016](https://doi.org/10.1007/978-3-319-40578-0_22)
-	function TBS(perm : Int[], qubits : Qubit[]) : MCTGate[] {
-		let masks = TBSMain(perm);
-		return GateMasksToToffoliGates(qubits, masks);
-	}
-
-	////////////////////////////////////////////////////////////
-	// Generic permutation synthesis                          //
-	////////////////////////////////////////////////////////////
-
-	// # Summary
-	// Synthesize Toffoli network from a permutation using functional synthesis
-	operation PermutationOracle(perm : Int[], qubits : Qubit[], synth : ((Int[], Qubit[]) -> MCTGate[])) : () {
-		body {
-			let gates = synth(perm, qubits);
-			for (i in 0..Length(gates) - 1) {
-				let (controls, target) = gates[i];
-				(Controlled X)(controls, target);
-			}
-		}
-		adjoint auto
-	}
+    // # Summary
+    // Returns all position in which bits of an integer are set
+    function IntegerBits(value : Int, length : Int) : Int[] {
+        return Filter(IsBitSet(value, _), Numbers(length));
+    }
 
     ////////////////////////////////////////////////////////////
-	// Example program to synthesize a permutation            //
-	////////////////////////////////////////////////////////////
+    // Transformation-based synthesis                         //
+    ////////////////////////////////////////////////////////////
 
-	// # Summary
-	// Takes as input a permutation, finds a quantum circuit using
-	// transformation-based synthesis, and checks whether the circuit realizes
-	// the input permutation
-	//
-	// # Input
-	// ## perm
-	// A permutation of 2^𝑛 elements starting from 0
-	//
-	// # Output
-	// True, if the circuit correctly implements the permutation
-    operation PermutationSimulation(perm : Int[]) : Bool {
-        body {
-		    mutable result = true;
-			let nbits = BitSize(Length(perm));
+    // # Summary
+    // A type to represent a multiple-controlled multiple-target Toffoli gate
+    //
+    // The first integer is a bit mask for control lines.  Bit indexes which
+    // are set correspond to control line indexes.
+    //
+    // The second integer is a bit mask for target lines.  Bit indexes which
+    // are set correspond to target line indexes.
+    //
+    // The bit indexes of both integers must be disjoint.
+    newtype MCMTMask = (Int, Int);
 
-			for (i in 0..Length(perm) - 1) {
-				using (qubits = Qubit[nbits]) {
-					let init = BoolArrFromPositiveInt(i, nbits);
-					ApplyPauliFromBitString(PauliX, true, init, qubits);
-					PermutationOracle(perm, qubits, TBS);
-					let simres = MeasureInteger(LittleEndian(qubits));
-					if (simres != perm[i]) {
-						set result = false;
-					}
-				}
-			}
+    // # Summary
+    // A type to represent a multiple-controlled Toffoli gate
+    //
+    // The first value is an array of qubits for the control lines, the second value
+    // is a qubit for the target line.
+    //
+    // The target cannot be contained in the control lines.
+    newtype MCTGate = (Qubit[], Qubit);
 
-			return result;
+    // # Summary
+    // Constructs a MCMTMask type as a singleton array if targets is not 0,
+    // otherwise returns an empty array
+    function MakeGateMask(controls: Int, targets: Int) : MCMTMask[] {
+        if (targets != 0) {
+            return [MCMTMask(controls, targets)];
+        } else {
+            return new MCMTMask[0];
         }
     }
 
-	////////////////////////////////////////////////////////////
-	// Hidden shift problem using permutation and             //
-	// inner product                                          //
-	////////////////////////////////////////////////////////////
+    // # Summary
+    // Computes up to two MCMT masks to transform y to x
+    function GateMasksForAssignment(x : Int, y : Int) : MCMTMask[] {
+        let m01 = x &&& ~~~y;
+        let m10 = y &&& ~~~x;
 
-	// # Summary
-	// Computes the inner product using controlled Z gates
-	//
-	// # Input
-	// ## qubits
-	// List of an even number of qubits.  The function pairs qubits from the
-	// first half of the list with the second half of the list
-	operation InnerProduct(qubits : Qubit[]) : () {
-		body {
-			let n = Length(qubits) / 2;
-			for (i in 0..n - 1) {
-				(Controlled Z)([qubits[i]], qubits[n + i]);
-			}
-		}
-	}
+        return MakeGateMask(y, m01) + MakeGateMask(x, m10);
+    }
 
-	// # Summary
-	// Applies shift (+s) to list of qubits using Pauli X gates
-	operation ApplyShift(shift : Int, qubits : Qubit[]) : () {
-		body {
-			let n = Length(qubits);
-			let bits = BoolArrFromPositiveInt(shift, n);
-			ApplyPauliFromBitString(PauliX, true, bits, qubits);
-		}
+    // # Summary
+    // Update an output pattern according to gate mask
+    function UpdateOutputPattern(pattern : Int, gateMask : MCMTMask) : Int {
+        let (controls, targets) = gateMask;
+        if ( ( pattern &&& controls ) == controls ) {
+            return pattern ^^^ targets;
+        } else {
+            return pattern;
+        }
+    }
 
-		adjoint auto;
-	}
+    // # Summary
+    // Update permutation based according to gate mask
+    function UpdatePermutation(perm : Int[], gateMask: MCMTMask) : Int[] {
+        return Map(UpdateOutputPattern(_, gateMask), perm);
+    }
 
-	// # Summary
-	// Hidden-shift algorithm in which the bent function is the inner product
-	// and a permutation being applied to one operand of the inner product.
-	//
-	// # Input
-	// ## perm
-	// A permutation of 2^𝑛 elements starting from 0
-	// ## shift
-	// The hidden shift
-	//
-	// # Output
-	// The shift computed by the quantum circuit
-	//
-	// # References
-    // - [*Martin Roetteler*, 
-    //    Proc. SODA 2010, ACM, pp. 448-457, 2010](https://doi.org/10.1137/1.9781611973075.37)
-	operation HiddenShiftProblem(perm : Int[], shift : Int) : Int {
-		body {
-			let n = BitSize(Length(perm));
-            mutable result = 0;
+    // # Summary
+    // Computes gate masks to transform perm[x] to x and updates the current permutation
+    function TBSStep(state : (Int[], MCMTMask[]), x : Int) : (Int[], MCMTMask[]) {
+        let (perm, gates) = state;
+        let y = perm[x];
+        let masks = GateMasksForAssignment(x, y);
+        let new_perm = Fold(UpdatePermutation, perm, masks);
+        return (new_perm, gates + masks);
+    }
 
-			using (qubits = Qubit[2 * n]) {
-				let Superpos = ApplyToEachA(H, _);
-				let Shift = ApplyShift(shift, _);
-				let Synth = PermutationOracle(perm, _, TBS);
-				let PermX = ApplyToSubregisterA(Synth, Sequence(0, n - 1), _);
-				let PermY = ApplyToSubregisterA(Synth, Sequence(n, 2 * n - 1), _);
+    // # Summary
+    // Compute gate masks to synthesize permutation
+    function TBSMain(perm : Int[]) : MCMTMask[] {
+        let xs = Numbers(Length(perm));
+        let gates = new MCMTMask[0];
+        return Reverse(Snd(Fold(TBSStep, (perm, gates), xs)));
+    }
 
-				With(BindA([Superpos; Shift; PermY]), InnerProduct, qubits);
-				With((Adjoint PermX), InnerProduct, qubits);
-				Superpos(qubits);
+    // # Summary
+    // Translate MCT masks into multiple-controlled Toffoli gates (with single targets)
+    function GateMasksToToffoliGates(qubits : Qubit[], masks : MCMTMask[]) : MCTGate[] {
+        mutable result = new MCTGate[0];
+        let n = Length(qubits); 
 
-				set result = MeasureInteger(LittleEndian(qubits));
-			}
+        for (i in 0..Length(masks) - 1) {
+            let (controls, targets) = masks[i];
+            let controlBits = IntegerBits(controls, n);
+            let targetBits = IntegerBits(targets, n);
+            let cQubits = Subarray(controlBits, qubits);
+            let tQubits = Subarray(targetBits, qubits);
+            for (t in 0..Length(tQubits) - 1) {
+                set result = result + [MCTGate(cQubits, tQubits[t])];
+            }
+        }
+
+        return result;
+    }
+
+    // # Summary
+    // Transformation-based synthesis algorithm
+    //
+    // This procedure implements the unidirectional transformation based
+    // synthesis approach.  Input is a permutation π over 2^𝑛 elements {0, ...,
+    // 2^𝑛-1}, which represents an 𝑛-variable reversible Boolean function.  The
+    // algorithm performs iteratively the following steps:
+    //
+    // 1. Find smallest 𝑥 such that 𝑥 ≠ π(𝑥) = 𝑦
+    // 2. Find multiple-controlled Toffoli gates, which applied to the outputs
+    //    make π(𝑥) = 𝑥 and do not change π(𝑥') for all 𝑥' < 𝑥
+    //
+    // # Input
+    // ## perm
+    // A permutation of 2^𝑛 elements starting from 0
+    // ## qubits
+    // A list of 𝑛 qubits where the Toffoli gates are being applied to.  Note
+    // that the algorithm does not apply the gates.  But only prepares the
+    // Toffoli gates.  The function should be called as argument to the function
+    // PermutationOracle.
+    //
+    // # Output
+    // ## A list of multiple-controlled Toffoli gates
+    //
+    // # References
+    // - [*D. Michael Miller*, *Dmitri Maslov*, *Gerhard W. Dueck*,
+    //    Proc. DAC 2003, IEEE, pp. 318-323, 2003](https://doi.org/10.1145/775832.775915)
+    // - [*Mathias Soeken*, *Gerhard W. Dueck*, *D. Michael Miller*,
+    //    Proc. RC 2016, Springer, pp. 307-321, 2016](https://doi.org/10.1007/978-3-319-40578-0_22)
+    function TBS(perm : Int[], qubits : Qubit[]) : MCTGate[] {
+        let masks = TBSMain(perm);
+        return GateMasksToToffoliGates(qubits, masks);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Generic permutation synthesis                          //
+    ////////////////////////////////////////////////////////////
+
+    // # Summary
+    // Synthesize Toffoli network from a permutation using functional synthesis
+    operation PermutationOracle(perm : Int[], qubits : Qubit[], synth : ((Int[], Qubit[]) -> MCTGate[])) : () {
+        body {
+            let gates = synth(perm, qubits);
+            for (i in 0..Length(gates) - 1) {
+                let (controls, target) = gates[i];
+                (Controlled X)(controls, target);
+            }
+        }
+        adjoint auto
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Example program to synthesize a permutation            //
+    ////////////////////////////////////////////////////////////
+
+    // # Summary
+    // Takes as input a permutation, finds a quantum circuit using
+    // transformation-based synthesis, and checks whether the circuit realizes
+    // the input permutation
+    //
+    // # Input
+    // ## perm
+    // A permutation of 2^𝑛 elements starting from 0
+    //
+    // # Output
+    // True, if the circuit correctly implements the permutation
+    operation PermutationSimulation(perm : Int[]) : Bool {
+        body {
+            mutable result = true;
+            let nbits = BitSize(Length(perm));
+
+            for (i in 0..Length(perm) - 1) {
+                using (qubits = Qubit[nbits]) {
+                    let init = BoolArrFromPositiveInt(i, nbits);
+                    ApplyPauliFromBitString(PauliX, true, init, qubits);
+                    PermutationOracle(perm, qubits, TBS);
+                    let simres = MeasureInteger(LittleEndian(qubits));
+                    if (simres != perm[i]) {
+                        set result = false;
+                    }
+                }
+            }
 
             return result;
-		}
-	}
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Hidden shift problem using permutation and             //
+    // inner product                                          //
+    ////////////////////////////////////////////////////////////
+
+    // # Summary
+    // Computes the inner product using controlled Z gates
+    //
+    // # Input
+    // ## qubits
+    // List of an even number of qubits.  The function pairs qubits from the
+    // first half of the list with the second half of the list
+    operation InnerProduct(qubits : Qubit[]) : () {
+        body {
+            let n = Length(qubits) / 2;
+            for (i in 0..n - 1) {
+                (Controlled Z)([qubits[i]], qubits[n + i]);
+            }
+        }
+    }
+
+    // # Summary
+    // Applies shift (+s) to list of qubits using Pauli X gates
+    operation ApplyShift(shift : Int, qubits : Qubit[]) : () {
+        body {
+            let n = Length(qubits);
+            let bits = BoolArrFromPositiveInt(shift, n);
+            ApplyPauliFromBitString(PauliX, true, bits, qubits);
+        }
+
+        adjoint auto;
+    }
+
+    // # Summary
+    // Hidden-shift algorithm in which the bent function is the inner product
+    // and a permutation being applied to one operand of the inner product.
+    //
+    // # Input
+    // ## perm
+    // A permutation of 2^𝑛 elements starting from 0
+    // ## shift
+    // The hidden shift
+    //
+    // # Output
+    // The shift computed by the quantum circuit
+    //
+    // # References
+    // - [*Martin Roetteler*, 
+    //    Proc. SODA 2010, ACM, pp. 448-457, 2010](https://doi.org/10.1137/1.9781611973075.37)
+    operation HiddenShiftProblem(perm : Int[], shift : Int) : Int {
+        body {
+            let n = BitSize(Length(perm));
+            mutable result = 0;
+
+            using (qubits = Qubit[2 * n]) {
+                let Superpos = ApplyToEachA(H, _);
+                let Shift = ApplyShift(shift, _);
+                let Synth = PermutationOracle(perm, _, TBS);
+                let PermX = ApplyToSubregisterA(Synth, Sequence(0, n - 1), _);
+                let PermY = ApplyToSubregisterA(Synth, Sequence(n, 2 * n - 1), _);
+
+                With(BindA([Superpos; Shift; PermY]), InnerProduct, qubits);
+                With((Adjoint PermX), InnerProduct, qubits);
+                Superpos(qubits);
+
+                set result = MeasureInteger(LittleEndian(qubits));
+            }
+
+            return result;
+        }
+    }
 }

--- a/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
+++ b/Samples/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
@@ -1,0 +1,304 @@
+// Author: Mathias Soeken, EPFL (Mail: mathias.soeken@epfl.ch)
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Samples.ReversibleLogicSynthesis {
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Canon;
+
+    // Some helper functions
+
+	// # Summary
+	// Checks whether bit at position is set in value
+	//
+	// # Note
+	// Implementation with right-shift did not work
+	function IsBitSet(value : Int, position : Int) : Bool {
+		return (value &&& 2^position) == 2^position;
+	}
+
+	// # Summary
+	// Get an array of integers in a given interval
+	function Sequence(from : Int, to : Int) : Int[] {
+		let n = to - from + 1;
+		mutable array = new Int[n];
+		for (i in 0..n - 1) {
+			set array[i] = from + i;
+		}
+		return array;
+	}
+	
+	// # Summary
+	// Get a sequence of numbers starting from 0
+	function Numbers(count : Int) : Int[] {
+		mutable array = new Int[count];
+		for (i in 0..count - 1) {
+			set array[i] = i;
+		}
+		return array;
+	}
+
+    // # Summary
+	// Returns all position in which bits of an integer are set
+	function IntegerBits(value : Int, length : Int) : Int[] {
+		return Filter(IsBitSet(value, _), Numbers(length));
+	}
+
+	////////////////////////////////////////////////////////////
+	// Transformation-based synthesis                         //
+	////////////////////////////////////////////////////////////
+
+	// # Summary
+	// A type to represent a multiple-controlled multiple-target Toffoli gate
+	//
+	// The first integer is a bit mask for control lines.  Bit indexes which
+	// are set correspond to control line indexes.
+	//
+	// The second integer is a bit mask for target lines.  Bit indexes which
+	// are set correspond to target line indexes.
+	//
+	// The bit indexes of both integers must be disjoint.
+	newtype MCMTMask = (Int, Int);
+
+	// # Summary
+	// A type to represent a multiple-controlled Toffoli gate
+	//
+	// The first value is an array of qubits for the control lines, the second value
+	// is a qubit for the target line.
+	//
+	// The target cannot be contained in the control lines.
+	newtype MCTGate = (Qubit[], Qubit);
+
+	// # Summary
+	// Constructs a MCMTMask type as a singleton array if targets is not 0,
+	// otherwise returns an empty array
+	function MakeGateMask(controls: Int, targets: Int) : MCMTMask[] {
+		if (targets != 0) {
+			return [MCMTMask(controls, targets)];
+		} else {
+			return new MCMTMask[0];
+		}
+	}
+
+	// # Summary
+	// Computes up to two MCMT masks to transform y to x
+	function GateMasksForAssignment(x : Int, y : Int) : MCMTMask[] {
+		let m01 = x &&& ~~~y;
+		let m10 = y &&& ~~~x;
+
+		return MakeGateMask(y, m01) + MakeGateMask(x, m10);
+	}
+
+	// # Summary
+	// Update an output pattern according to gate mask
+	function UpdateOutputPattern(pattern : Int, gateMask : MCMTMask) : Int {
+		let (controls, targets) = gateMask;
+		if ( ( pattern &&& controls ) == controls ) {
+			return pattern ^^^ targets;
+		} else {
+			return pattern;
+		}
+	}
+
+	// # Summary
+	// Update permutation based according to gate mask
+	function UpdatePermutation(perm : Int[], gateMask: MCMTMask) : Int[] {
+		return Map(UpdateOutputPattern(_, gateMask), perm);
+	}
+
+	// # Summary
+	// Computes gate masks to transform perm[x] to x and updates the current permutation
+	function TBSStep(state : (Int[], MCMTMask[]), x : Int) : (Int[], MCMTMask[]) {
+	    let (perm, gates) = state;
+		let y = perm[x];
+		let masks = GateMasksForAssignment(x, y);
+		let new_perm = Fold(UpdatePermutation, perm, masks);
+		return (new_perm, gates + masks);
+	}
+
+	// # Summary
+	// Compute gate masks to synthesize permutation
+	function TBSMain(perm : Int[]) : MCMTMask[] {
+		let xs = Numbers(Length(perm));
+		let gates = new MCMTMask[0];
+		return Reverse(Snd(Fold(TBSStep, (perm, gates), xs)));
+	}
+
+	// # Summary
+	// Translate MCT masks into multiple-controlled Toffoli gates (with single targets)
+	function GateMasksToToffoliGates(qubits : Qubit[], masks : MCMTMask[]) : MCTGate[] {
+		mutable result = new MCTGate[0];
+		let n = Length(qubits); 
+
+		for (i in 0..Length(masks) - 1) {
+			let (controls, targets) = masks[i];
+			let controlBits = IntegerBits(controls, n);
+			let targetBits = IntegerBits(targets, n);
+			let cQubits = Subarray(controlBits, qubits);
+			let tQubits = Subarray(targetBits, qubits);
+			for (t in 0..Length(tQubits) - 1) {
+				set result = result + [MCTGate(cQubits, tQubits[t])];
+			}
+		}
+
+		return result;
+	}
+
+	// # Summary
+	// Transformation-based synthesis algorithm
+	//
+	// This procedure implements the unidirectional transformation based
+	// synthesis approach.  Input is a permutation π over 2^𝑛 elements {0, ...,
+	// 2^𝑛-1}, which represents an 𝑛-variable reversible Boolean function.  The
+	// algorithm performs iteratively the following steps:
+	//
+	// 1. Find smallest 𝑥 such that 𝑥 ≠ π(𝑥) = 𝑦
+	// 2. Find multiple-controlled Toffoli gates, which applied to the outputs
+	//    make π(𝑥) = 𝑥 and do not change π(𝑥') for all 𝑥' < 𝑥
+	//
+	// # Input
+	// ## perm
+	// A permutation of 2^𝑛 elements starting from 0
+	// ## qubits
+	// A list of 𝑛 qubits where the Toffoli gates are being applied to.  Note
+	// that the algorithm does not apply the gates.  But only prepares the
+	// Toffoli gates.  The function should be called as argument to the function
+	// PermutationOracle.
+	//
+	// # Output
+	// ## A list of multiple-controlled Toffoli gates
+	//
+	// # References
+    // - [*D. Michael Miller*, *Dmitri Maslov*, *Gerhard W. Dueck*,
+    //    Proc. DAC 2003, IEEE, pp. 318-323, 2003](https://doi.org/10.1145/775832.775915)
+	// - [*Mathias Soeken*, *Gerhard W. Dueck*, *D. Michael Miller*,
+    //    Proc. RC 2016, Springer, pp. 307-321, 2016](https://doi.org/10.1007/978-3-319-40578-0_22)
+	function TBS(perm : Int[], qubits : Qubit[]) : MCTGate[] {
+		let masks = TBSMain(perm);
+		return GateMasksToToffoliGates(qubits, masks);
+	}
+
+	////////////////////////////////////////////////////////////
+	// Generic permutation synthesis                          //
+	////////////////////////////////////////////////////////////
+
+	// # Summary
+	// Synthesize Toffoli network from a permutation using functional synthesis
+	operation PermutationOracle(perm : Int[], qubits : Qubit[], synth : ((Int[], Qubit[]) -> MCTGate[])) : () {
+		body {
+			let gates = synth(perm, qubits);
+			for (i in 0..Length(gates) - 1) {
+				let (controls, target) = gates[i];
+				(Controlled X)(controls, target);
+			}
+		}
+		adjoint auto
+	}
+
+    ////////////////////////////////////////////////////////////
+	// Example program to synthesize a permutation            //
+	////////////////////////////////////////////////////////////
+
+	// # Summary
+	// Takes as input a permutation, finds a quantum circuit using
+	// transformation-based synthesis, and checks whether the circuit realizes
+	// the input permutation
+	//
+	// # Input
+	// ## perm
+	// A permutation of 2^𝑛 elements starting from 0
+	//
+	// # Output
+	// True, if the circuit correctly implements the permutation
+    operation PermutationSimulation(perm : Int[]) : Bool {
+        body {
+		    mutable result = true;
+			let nbits = BitSize(Length(perm));
+
+			for (i in 0..Length(perm) - 1) {
+				using (qubits = Qubit[nbits]) {
+					let init = BoolArrFromPositiveInt(i, nbits);
+					ApplyPauliFromBitString(PauliX, true, init, qubits);
+					PermutationOracle(perm, qubits, TBS);
+					let simres = MeasureInteger(LittleEndian(qubits));
+					if (simres != perm[i]) {
+						set result = false;
+					}
+				}
+			}
+
+			return result;
+        }
+    }
+
+	////////////////////////////////////////////////////////////
+	// Hidden shift problem using permutation and             //
+	// inner product                                          //
+	////////////////////////////////////////////////////////////
+
+	// # Summary
+	// Computes the inner product using controlled Z gates
+	//
+	// # Input
+	// ## qubits
+	// List of an even number of qubits.  The function pairs qubits from the
+	// first half of the list with the second half of the list
+	operation InnerProduct(qubits : Qubit[]) : () {
+		body {
+			let n = Length(qubits) / 2;
+			for (i in 0..n - 1) {
+				(Controlled Z)([qubits[i]], qubits[n + i]);
+			}
+		}
+	}
+
+	// # Summary
+	// Applies shift (+s) to list of qubits using Pauli X gates
+	operation ApplyShift(shift : Int, qubits : Qubit[]) : () {
+		body {
+			let n = Length(qubits);
+			let bits = BoolArrFromPositiveInt(shift, n);
+			ApplyPauliFromBitString(PauliX, true, bits, qubits);
+		}
+
+		adjoint auto;
+	}
+
+	// # Summary
+	// Hidden-shift algorithm in which the bent function is the inner product
+	// and a permutation being applied to one operand of the inner product.
+	//
+	// # Input
+	// ## perm
+	// A permutation of 2^𝑛 elements starting from 0
+	// ## shift
+	// The hidden shift
+	//
+	// # Output
+	// The shift computed by the quantum circuit
+	//
+	// # References
+    // - [*Martin Roetteler*, 
+    //    Proc. SODA 2010, ACM, pp. 448-457, 2010](https://doi.org/10.1137/1.9781611973075.37)
+	operation HiddenShiftProblem(perm : Int[], shift : Int) : Int {
+		body {
+			let n = BitSize(Length(perm));
+            mutable result = 0;
+
+			using (qubits = Qubit[2 * n]) {
+				let Superpos = ApplyToEachA(H, _);
+				let Shift = ApplyShift(shift, _);
+				let Synth = PermutationOracle(perm, _, TBS);
+				let PermX = ApplyToSubregisterA(Synth, Sequence(0, n - 1), _);
+				let PermY = ApplyToSubregisterA(Synth, Sequence(n, 2 * n - 1), _);
+
+				With(BindA([Superpos; Shift; PermY]), InnerProduct, qubits);
+				With((Adjoint PermX), InnerProduct, qubits);
+				Superpos(qubits);
+
+				set result = MeasureInteger(LittleEndian(qubits));
+			}
+
+            return result;
+		}
+	}
+}


### PR DESCRIPTION
This is an Q# implementation of the unidirectional variant of the transformation based synthesis approach [Miller, Maslov, Dueck, *DAC* 2003].

There are two example operations that are using the automatic synthesis algorithms. The first example finds the circuit for the permutation and checks whether it correctly computes the permutation using exhaustive simulation of all input patterns. The second example implements an instance of the hidden-shift quantum algorithm, in which the bent function is the inner product applied to a two set of qubits, where the first set of qubits is permuted.

I tried to follow code conventions and documentation styles as I saw it in other samples.