### PR TITLE
Small version updates.

### DIFF
--- a/Samples/H2SimulationGUI/package-lock.json
+++ b/Samples/H2SimulationGUI/package-lock.json
@@ -128,12 +128,12 @@
             "dev": true
         },
         "chart.js": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.1.tgz",
-            "integrity": "sha512-pX1oQAY86MiuyZ2hY593Acbl4MLHKrBBhhmZ1YqSadzQbbsBE2rnd6WISoHjIsdf0WDeC0hbePYCz2ZxkV8L+g==",
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.2.tgz",
+            "integrity": "sha512-90wl3V9xRZ8tnMvMlpcW+0Yg13BelsGS9P9t0ClaDxv/hdypHDr/YAGf+728m11P5ljwyB0ZHfPKCapZFqSqYA==",
             "requires": {
                 "chartjs-color": "2.2.0",
-                "moment": "2.18.1"
+                "moment": "2.19.3"
             }
         },
         "chartjs-color": {
@@ -801,9 +801,9 @@
             }
         },
         "moment": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-            "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+            "version": "2.19.3",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+            "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
         },
         "ms": {
             "version": "2.0.0",

--- a/Samples/H2SimulationGUI/package.json
+++ b/Samples/H2SimulationGUI/package.json
@@ -12,6 +12,6 @@
     },
     "dependencies": {
         "node-ipc": "9.1.1",
-        "chart.js": "2.7.1"
+        "chart.js": "2.7.2"
     }
 }

--- a/Samples/PythonInterop/environment.yml
+++ b/Samples/PythonInterop/environment.yml
@@ -10,7 +10,7 @@ name: qsharp-samples
 channels:
     - conda-forge
     - pythonnet
-    - https://solidrepo.blob.core.windows.net/release/latest/qdk-channel
+    - https://solidrepo.blob.core.windows.net/release/1802.2202/src/python/bin/package
 dependencies:
     - python>=3.6
     - numpy


### PR DESCRIPTION
Updating version of chart.js as one of its dependencies has a known vulnerability (on server applications, so it doesn't affect us). 
Fixing location of qsharp's python channel to match build version, so updates to latest doesn't break it.