### PR TITLE
Update GCC on Travis CI to enable Linux build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ mono: none
 matrix:
   include:
     - os: osx
+
+    # The default image for Linux provided by Travis CI uses GCC 4.8,
+    # but since GCC also includes the GNU implementation of OpenMP,
+    # we need to update GCC to get the version of OpenMP that the
+    # Quantum Development Kit was built against. To do so, we add
+    # the APT source provided by Travis CI for more recent versions
+    # of GCC backported to Ubuntu 14.04 Trusty.
     - os: linux
       addons:
         apt:
@@ -14,11 +21,6 @@ matrix:
             - g++-4.9
 
 script:
-  # If we're on Linux, print out the dynamic linker configuration for the quantum
-  # runtime to see what dependencies we're missing.
-  - dotnet restore QsharpLibraries.sln
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd `find ~/.nuget/packages -name "Microsoft.Quantum.Simulator.Runtime.dll"`; fi
   - dotnet build QsharpLibraries.sln
   - dotnet test Samples/UnitTesting
   - travis_wait dotnet test LibraryTests
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
   - linux
 
 script:
+  # If we're on Linux, print out the dynamic linker configuration for the quantum
+  # runtime to see what dependencies we're missing.
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd `find . -name "Microsoft.Quantum.Simulator.Runtime.dll"`; fi
   - dotnet build QsharpLibraries.sln
   - dotnet test Samples/UnitTesting
   - travis_wait dotnet test LibraryTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   # If we're on Linux, print out the dynamic linker configuration for the quantum
   # runtime to see what dependencies we're missing.
   - dotnet restore QsharpLibraries.sln
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd `find . -name "Microsoft.Quantum.Simulator.Runtime.dll"`; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd `find ~/.nuget/packages -name "Microsoft.Quantum.Simulator.Runtime.dll"`; fi
   - dotnet build QsharpLibraries.sln
   - dotnet test Samples/UnitTesting
   - travis_wait dotnet test LibraryTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: csharp
 dotnet: 2.1.4
 mono: none
-os:
-  - osx
-  - linux
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
 
 script:
   # If we're on Linux, print out the dynamic linker configuration for the quantum

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 script:
   # If we're on Linux, print out the dynamic linker configuration for the quantum
   # runtime to see what dependencies we're missing.
+  - dotnet restore QsharpLibraries.sln
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd `find . -name "Microsoft.Quantum.Simulator.Runtime.dll"`; fi
   - dotnet build QsharpLibraries.sln
   - dotnet test Samples/UnitTesting

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: csharp
 dotnet: 2.1.4
 mono: none
-os: osx
+os:
+  - osx
+  - linux
 
 script:
   - dotnet build QsharpLibraries.sln


### PR DESCRIPTION
This PR updates the version of GCC installed on the Travis CI build image such that the correct GNU OpenMP implementation is available to the simulator runtime. This allows the the Linux builds to successfully complete, so the PR also enables Travis CI testing on both macOS and Linux.