### PR TITLE
Adding RunQDocGen flag to Canon

### DIFF
--- a/Microsoft.Quantum.Canon/Microsoft.Quantum.Canon.csproj
+++ b/Microsoft.Quantum.Canon/Microsoft.Quantum.Canon.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;1705;0162;0219</NoWarn>
+    <RunQDocGen>True</RunQDocGen>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The flag went missing when we migrated to .net core. We needed to generate API docs.