### PR TITLE
Fixing links to xref docs

### DIFF
--- a/Microsoft.Quantum.Canon/Simulation/Algorithms.qs
+++ b/Microsoft.Quantum.Canon/Simulation/Algorithms.qs
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// For more on the Trotter–Suzuki decomposition, see
-    /// [Time-Ordered Composition](xref:microsoft.quantum.concepts.control-flow#time-ordered-composition).
+    /// [Time-Ordered Composition](/quantum/libraries/control-flow#time-ordered-composition).
     function TrotterStep(evolutionGenerator: EvolutionGenerator, trotterOrder: Int, trotterStepSize: Double) : (Qubit[] => () :  Adjoint, Controlled)
     {
         let (evolutionSet, generatorSystem) = evolutionGenerator;

--- a/Microsoft.Quantum.Canon/Simulation/PauliEvolutionSet.qs
+++ b/Microsoft.Quantum.Canon/Simulation/PauliEvolutionSet.qs
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.Canon {
     /// Represents a dynamical generator as a set of simulatable gates and an 
     /// expansion in the Pauli basis.
     ///
-    /// See [Dynamical Generator Modeling](../libraries/data-structures#dynamical-generator-modeling)
+    /// See [Dynamical Generator Modeling](/quantum/libraries/data-structures#dynamical-generator-modeling)
     /// for more details.
     ///
     /// # Input

--- a/Microsoft.Quantum.Canon/Simulation/Techniques.qs
+++ b/Microsoft.Quantum.Canon/Simulation/Techniques.qs
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Canon {
     /// $\ket{\phi}$ and ground state energy $E = \phi\\,\delta t$.
     /// ## phaseEstAlgorithm
     /// An operation that performs phase estimation on a given unitary operation.
-    /// See [iterative phase estimation](../libraries/characterization#iterative-phase-estimation)
+    /// See [iterative phase estimation](/quantum/libraries/characterization#iterative-phase-estimation)
     /// for more details.
     /// ## qubits
     /// A register of qubits to be used to perform the simulation.
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Canon {
     /// $\ket{\phi}$ and ground state energy $E = \phi\\,\delta t$.
     /// ## phaseEstAlgorithm
     /// An operation that performs phase estimation on a given unitary operation.
-    /// See [iterative phase estimation](../libraries/characterization#iterative-phase-estimation)
+    /// See [iterative phase estimation](/quantum/libraries/characterization#iterative-phase-estimation)
     /// for more details.
     ///
     /// # Output
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Canon {
     /// $\ket{\phi}$ and ground state energy $E = \phi\\,\delta t$.
     /// ## phaseEstAlgorithm
     /// An operation that performs phase estimation on a given unitary operation.
-    /// See [iterative phase estimation](../libraries/characterization#iterative-phase-estimation)
+    /// See [iterative phase estimation](/quantum/libraries/characterization#iterative-phase-estimation)
     /// for more details.
     ///
     /// # Output


### PR DESCRIPTION
Relative paths are not supported for xref links.

The correct way is to use the docset name.
