### PR TITLE
Fix for #62: RobustPhaseEstimationTest is flaky

### DIFF
--- a/LibraryTests/SimulatorTestTargets.cs
+++ b/LibraryTests/SimulatorTestTargets.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Tests
         {
             this.output = output;
             fixedSeeds = new Dictionary<string, uint>();
-            fixedSeeds.Add(" Microsoft.Quantum.Tests.RobustPhaseEstimationTest", 2020776761);
+            fixedSeeds.Add("Microsoft.Quantum.Tests.RobustPhaseEstimationTest", 2020776761);
         }
 
         // note that one can provide custom namespace where to search for tests


### PR DESCRIPTION
Fix for #62
Space in the class name accidently made the test use a random value instead of using the fixed value required for the test.