### PR TITLE
Typo corrections

### DIFF
--- a/Interoperability/python/qsharp/__init__.py
+++ b/Interoperability/python/qsharp/__init__.py
@@ -223,8 +223,8 @@ class Callable(WrappedCLRObject):
         
         if isinstance(type(output), CLR_METATYPE):
             # Try to wrap the output as best as we can.
-            # We provide convienence wrappers for a few, so we call the
-            # single-dispatched convienence function above.
+            # We provide convenience wrappers for a few, so we call the
+            # single-dispatched convenience function above.
             return wrap_clr_object(output)
         else:
             return output

--- a/LibraryTests/MultiplexerTests.qs
+++ b/LibraryTests/MultiplexerTests.qs
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.Tests {
             let nQubits = Length(qubits);
 
             
-            // The absolute phase of a diagonal unitary can only be characeterized
+            // The absolute phase of a diagonal unitary can only be characterized
             // using a controlled operation.
             using(control = Qubit[1]){
                 for(idxCoeff in 0..Length(coefficients) -1 ){

--- a/LibraryTests/Simulation/Tests.qs
+++ b/LibraryTests/Simulation/Tests.qs
@@ -381,7 +381,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     /// summary:
-    ///     Checks that operations containing == are equal to themseleves.
+    ///     Checks that operations containing == are equal to themselves.
     operation ConditionalOperationTest() : () {
         body {
             AssertOperationsEqualReferenced(ExpTestHelper(_, 0), ExpTestHelper(_, 0), 2);

--- a/LibraryTests/StatePreparationTests.qs
+++ b/LibraryTests/StatePreparationTests.qs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Tests {
             set testCases[nTests] = StatePreparationTestCase(3, [1.0986553; 0.359005; 0.465689; -0.467395; 0.419893; 0.118445; 0.461883; 0.149609], new Double[0]);
             set nTests = nTests + 1;
 
-            // Test missing coefficicients
+            // Test missing coefficients
             set testCases[nTests] = StatePreparationTestCase(3, [1.0986553; 0.359005; 0.465689; -0.467395; 0.419893; 0.118445], new Double[0]);
             set nTests = nTests + 1;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Tests {
                 let nCoefficients = Length(coefficientsAmplitude);
 
 
-                // Test negative coefficicients. Should give same results as positive coefficients.
+                // Test negative coefficients. Should give same results as positive coefficients.
                 using(qubits = Qubit[nQubits]){
                     let qubitsBE = BigEndian(qubits);
 

--- a/Microsoft.Quantum.Canon/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Microsoft.Quantum.Canon/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.Canon {
     // amplitude amplifiction where `ObliviousOracle` is the identity operator,
     // and there are no system qubits i.e. `systemRegister` is empty.
     //
-    //		This is called through the operaton `AmpAmByReflectionPhases` and 
+    //		This is called through the operation `AmpAmByReflectionPhases` and 
     //      `AmpAmpByOraclePhases`.
     //
     // The phases for partial reflections in the standard case of Grover 
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.Canon {
     /// Target minimum success probability.
     ///
     /// # Output
-    /// Array of phases that can be used in fixed-point amplitide amplification
+    /// Array of phases that can be used in fixed-point amplitude amplification
     /// quantum algorithm implementation.
     ///
     /// # References

--- a/Microsoft.Quantum.Canon/AmplitudeAmplification/Utils.qs
+++ b/Microsoft.Quantum.Canon/AmplitudeAmplification/Utils.qs
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Canon {
     /// A state preparation oracle $A$ of type `StateOracle`.
     ///
     /// # Output
-    /// The same state prepataion oracle $A$, but now of type 
+    /// The same state preparation oracle $A$, but now of type 
     /// `DeterministicStateOracle`, so it acts on a register where $a,s$ no 
     /// longer explicitly separate, e.g.  $A\ket{0\psi}\_{as}$.
     ///
@@ -138,7 +138,7 @@ namespace Microsoft.Quantum.Canon {
     /// A state preparation oracle $A$ of type `DeterministicStateOracle`.
     ///
     /// # Output
-    /// The same state prepataion oracle $A$, but now of type
+    /// The same state preparation oracle $A$, but now of type
     /// `StateOracle`. Note that the flag index in this `StateOracle` is a
     /// dummy variable and has no effect.
     ///

--- a/Microsoft.Quantum.Canon/Arrays/Arrays.qs
+++ b/Microsoft.Quantum.Canon/Arrays/Arrays.qs
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Input
     /// ## array
-    /// An array whose fisrt to second-to-last elements are to form the output array.
+    /// An array whose first to second-to-last elements are to form the output array.
     ///
     /// # Output
     /// An array containing the elements `array[0..Length(array) - 2]`.

--- a/Microsoft.Quantum.Canon/Asserts/QuantumAsserts.qs
+++ b/Microsoft.Quantum.Canon/Asserts/QuantumAsserts.qs
@@ -113,11 +113,11 @@ namespace Microsoft.Quantum.Canon
     /// - `AssertPhase(-1.2,qubit,10e-10);`
     operation AssertPhase(expected: Double, qubit: Qubit, tolerance: Double) : () {
         body{
-            let exptectedProbX = Cos(expected)*Cos(expected);
-            let exptectedProbY = Sin(-1.0*expected+PI()/4.0)*Sin(-1.0*expected+PI()/4.0);
+            let expectedProbX = Cos(expected)*Cos(expected);
+            let expectedProbY = Sin(-1.0*expected+PI()/4.0)*Sin(-1.0*expected+PI()/4.0);
             AssertProb([PauliZ], [qubit], Zero, 0.5, $"AssertPhase failed. Was not given a uniform superposition.",  tolerance);
-            AssertProb([PauliY], [qubit], Zero, exptectedProbY, $"AssertPhase failed. PauliY Zero basis did not give probability {exptectedProbY}.",  tolerance);
-            AssertProb([PauliX], [qubit], Zero, exptectedProbX, $"AssertPhase failed. PauliX Zero basis did not give probability {exptectedProbX}.",  tolerance);
+            AssertProb([PauliY], [qubit], Zero, expectedProbY, $"AssertPhase failed. PauliY Zero basis did not give probability {expectedProbY}.",  tolerance);
+            AssertProb([PauliX], [qubit], Zero, expectedProbX, $"AssertPhase failed. PauliX Zero basis did not give probability {expectedProbX}.",  tolerance);
         }
     }
 }

--- a/Microsoft.Quantum.Canon/Data/GeneratorRepresentation.qs
+++ b/Microsoft.Quantum.Canon/Data/GeneratorRepresentation.qs
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Canon {
 
     /// # Summary
     /// Represents a unitary time-evolution operator. The first parameter is
-    /// is duration of time-evoltion, and the second parameter is the qubit
+    /// is duration of time-evolution, and the second parameter is the qubit
     /// register acted upon by the unitary.
     newtype EvolutionUnitary = ((Double, Qubit[]) => () : Adjoint, Controlled);
 
@@ -190,8 +190,8 @@ namespace Microsoft.Quantum.Canon {
     /// # Example
     /// ```qsharp
     /// let gen = GeneratorIndex(([1;2;3],[coeff]),[1;2;3);
-    /// let ((idxPaulis, idxDoubles), idxQubits) = MultiplyGeneratorIndex(multipler, gen);
-    /// // idxDoubles[0] == multipler * coeff;
+    /// let ((idxPaulis, idxDoubles), idxQubits) = MultiplyGeneratorIndex(multiplier, gen);
+    /// // idxDoubles[0] == multiplier * coeff;
     /// ```
     ///
     /// # See Also

--- a/Microsoft.Quantum.Canon/Enumeration/Subarray.qs
+++ b/Microsoft.Quantum.Canon/Enumeration/Subarray.qs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Canon {
     /// The construction of the subarray is a based on generating a new, deep 
     /// copy of the given array as opposed to maintaining references. 
     ///
-    /// If `Length(indices) < Lenth(array)`, this function will return a
+    /// If `Length(indices) < Length(array)`, this function will return a
     /// subset of `array`. On the other hand, if `indices` contains repeated
     /// elements, the corresponding elements of `array` will likewise be
     /// repeated.

--- a/Microsoft.Quantum.Canon/Math/Random.qs
+++ b/Microsoft.Quantum.Canon/Math/Random.qs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Canon {
     ///       
     /// # Remarks
     /// This function calls <xref:microsoft.quantum.primitive.random>, so
-    /// its randomess depends on the implementation of `Random`.
+    /// its randomness depends on the implementation of `Random`.
 	operation RandomIntPow2 (maxBits : Int) : Int
 	{
 		body {
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// This function calls <xref:microsoft.quantum.primitive.random>, so
-    /// its randomess depends on the implementation of `Random`.
+    /// its randomness depends on the implementation of `Random`.
 	operation RandomInt (maxInt : Int) : Int
 	{
 		body {
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// This function calls <xref:microsoft.quantum.primitive.random>, so
-    /// its randomess depends on the implementation of `Random`.
+    /// its randomness depends on the implementation of `Random`.
 	operation RandomReal (bitsRandom : Int) : Double {
 		body {
 			if (bitsRandom < 1) {

--- a/Microsoft.Quantum.Canon/Qcvv/ProcessTomography.qs
+++ b/Microsoft.Quantum.Canon/Qcvv/ProcessTomography.qs
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Canon {
 
     /// # Summary
     /// Given a preparation and measurement, estimates the frequency
-    /// with which that measurement suceeds (returns `Zero`) by
+    /// with which that measurement succeeds (returns `Zero`) by
     /// performing a given number of trials.
     ///
     /// # Input

--- a/Microsoft.Quantum.Canon/Qecc/5QubitCode.qs
+++ b/Microsoft.Quantum.Canon/Qecc/5QubitCode.qs
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.Canon {
     /// A qubit representing an unencoded state. This array `Qubit[]` is of 
     /// length 1.
     /// ## auxQubits
-    /// A register of auxillary qubits that will be used to represent the
+    /// A register of auxiliary qubits that will be used to represent the
     /// encoded state.
     ///
     /// # Output
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Output
     /// A qubit array of length 1 representing the unencoded state in the 
-    /// first parameter, together with auxillary qubits in the second parameter.
+    /// first parameter, together with auxiliary qubits in the second parameter.
     ///
     /// # See Also
     /// - microsoft.quantum.canon.FiveQubitCodeEncoder

--- a/Microsoft.Quantum.Canon/Qecc/7QubitCode.qs
+++ b/Microsoft.Quantum.Canon/Qecc/7QubitCode.qs
@@ -132,12 +132,12 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Output
     /// A qubit array of length 1 representing the unencoded state in the
-    /// first parameter, together with auxillary qubits in the second parameter.
+    /// first parameter, together with auxiliary qubits in the second parameter.
     ///
     /// # Remarks
     /// The chosen decoder uses the CSS code property of the ⟦7, 1, 3⟧ Steane code, i.e., it corrects X errors
     /// and Z errors separately. A property of the code is that the location of the X, respectively, Z correction
-    /// to be applied is the 3-bit encoding of the X, repsectively, Z syndrome when considered an integer.
+    /// to be applied is the 3-bit encoding of the X, respectively, Z syndrome when considered an integer.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.SteaneCodeEncoder

--- a/Microsoft.Quantum.Canon/Qecc/BitFlipCode.qs
+++ b/Microsoft.Quantum.Canon/Qecc/BitFlipCode.qs
@@ -36,11 +36,11 @@ namespace Microsoft.Quantum.Canon {
     /// ## physRegister
     /// A register of physical qubits representing the data to be protected.
     /// ## auxQubits
-    /// A register of auxillary qubits initially in the $\ket{00}$ state to be
+    /// A register of auxiliary qubits initially in the $\ket{00}$ state to be
     /// used in encoding the data to be protected.
     ///
     /// # Output
-    /// The physical and auxillary qubits used in encoding, represented as a
+    /// The physical and auxiliary qubits used in encoding, represented as a
     /// logical register.
     ///
     /// # See Also
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.Canon {
     /// A code block of the bit-flip code.
     ///
     /// # Output
-    /// A tuple of the data encoded into the logical register, and the auxillary
+    /// A tuple of the data encoded into the logical register, and the auxiliary
     /// qubits used to represent the syndrome.
     ///
     /// # See Also
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.Canon {
     }
 
     /// # Summary
-    /// Function for recovery Pauli operations for given symdrome measurement
+    /// Function for recovery Pauli operations for given syndrome measurement
     /// by table lookup for the ⟦3, 1, 1⟧ bit flip code.
     ///
     /// # Output

--- a/Microsoft.Quantum.Canon/Qecc/Types.qs
+++ b/Microsoft.Quantum.Canon/Qecc/Types.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Canon {
 
     // Design notes:
     //     These two types do not return (), such that instances of these types
-    //     will not support autofunctors. This is inconvienent, but I think it's
+    //     will not support autofunctors. This is inconvenient, but I think it's
     //     important to allow the generalization that physical and logical registers
     //     may have different numbers of qubits.
 
@@ -61,7 +61,7 @@ namespace Microsoft.Quantum.Canon {
     /// The signature `(LogicalRegister => Syndrome)` represents an operation 
     /// that acts jointly on the qubits in `LogicalRegister` and some ancilla
     /// qubits followed by a measurements of the ancilla to extract a `Syndrome
-    /// type represting the `Result[]` of these measurements.
+    /// type representing the `Result[]` of these measurements.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.LogicalRegister

--- a/Microsoft.Quantum.Canon/Qecc/Utils.qs
+++ b/Microsoft.Quantum.Canon/Qecc/Utils.qs
@@ -54,8 +54,8 @@ namespace Microsoft.Quantum.Canon {
 	/// # Input
 	/// ## code
 	/// A quantum error-correcting code packaged as a `QECC` type describes 
-    /// the encoding and deconding of quantum data, and how error syndromes 
-    /// are to be measuremed.
+    /// the encoding and decoding of quantum data, and how error syndromes 
+    /// are to be measured.
 	/// ## fn
     /// A `RecoveryFn` that maps each error syndrome to the `Pauli[]` operations
     /// that correct the detected error. 
@@ -83,8 +83,8 @@ namespace Microsoft.Quantum.Canon {
 	/// # Input
 	/// ## code
 	/// A quantum CSS error-correcting code packaged as a `CSS` type describes 
-    /// the encoding and deconding of quantum data, and how error syndromes 
-    /// are to be measuremed.
+    /// the encoding and decoding of quantum data, and how error syndromes 
+    /// are to be measured.
 	/// ## fnX
     /// A `RecoveryFn` that maps each $X$ error syndrome to the `Pauli[]` operations
     /// that correct the detected error. 

--- a/Microsoft.Quantum.Canon/Simulation/Algorithms.qs
+++ b/Microsoft.Quantum.Canon/Simulation/Algorithms.qs
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Canon {
         return SimulationAlgorithm(TrotterSimulationAlgorithmImpl(trotterStepSize,trotterOrder, _, _, _));
     }
 
-   // This simple time-depedendent simulation algorithm implements a
+   // This simple time-dependent simulation algorithm implements a
    // sequence of uniformly-sized trotter steps
 
     /// # Summary

--- a/Microsoft.Quantum.Canon/Simulation/Techniques.qs
+++ b/Microsoft.Quantum.Canon/Simulation/Techniques.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Canon {
     /// If the interpolation time is chosen to meet the adiabatic conditions,
     /// then this function returns an operation which performs adiabatic
     /// state preparation for the final dynamical generator.
-    function InterpolatedEvolution( inerpolationTime: Double,
+    function InterpolatedEvolution( interpolationTime: Double,
                                     evolutionGeneratorStart: EvolutionGenerator,
                                     evolutionGeneratorEnd: EvolutionGenerator,
                                     timeDependentSimulationAlgorithm: TimeDependentSimulationAlgorithm)
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Canon {
         let (evolutionSetEnd, generatorSystemEnd) = evolutionGeneratorEnd;
         let generatorSystemTimeDependent = InterpolateGeneratorSystems(generatorSystemStart, generatorSystemEnd);
         let evolutionSchedule = EvolutionSchedule(evolutionSetStart, generatorSystemTimeDependent);
-        return timeDependentSimulationAlgorithm(inerpolationTime, evolutionSchedule, _);
+        return timeDependentSimulationAlgorithm(interpolationTime, evolutionSchedule, _);
     }
 
 

--- a/Microsoft.Quantum.Canon/UnsignedIntegers.qs
+++ b/Microsoft.Quantum.Canon/UnsignedIntegers.qs
@@ -230,9 +230,9 @@ namespace Microsoft.Quantum.Canon {
     /// its original representation after application of `op`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationonLEA
-    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationonLEA
-    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationonLECA
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLEA
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLEA
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLECA
     operation ApplyPhaseLEOperationOnLE( op : (PhaseLittleEndian => ()), target : LittleEndian ) : () {
         body {
             QFTLE(target);
@@ -307,9 +307,9 @@ namespace Microsoft.Quantum.Canon {
     /// its original representation after application of `op`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLEA
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLEA
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLECA
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLEA
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLEA
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLECA
     operation ApplyLEOperationOnPhaseLE( op : (LittleEndian => ()), target : PhaseLittleEndian ) : () {
         body {
             let targetLE = LittleEndian(target);
@@ -318,7 +318,7 @@ namespace Microsoft.Quantum.Canon {
     }
 
     /// # See Also
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLE
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLE
     operation ApplyLEOperationOnPhaseLEA( op : (LittleEndian => () : Adjoint), target : PhaseLittleEndian ) : () {
         body {
             let targetLE = LittleEndian(target);
@@ -328,7 +328,7 @@ namespace Microsoft.Quantum.Canon {
     }
 
     /// # See Also
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLE
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLE
     operation ApplyLEOperationOnPhaseLEC( op : (LittleEndian => () : Controlled), target : PhaseLittleEndian ) : () {
         body {
             let targetLE = LittleEndian(target);
@@ -338,7 +338,7 @@ namespace Microsoft.Quantum.Canon {
     }
 
     /// # See Also
-    /// - Microsoft.Quantum.Canon.ApplyLEOperationonPhaseLE
+    /// - Microsoft.Quantum.Canon.ApplyLEOperationOnPhaseLE
     operation ApplyLEOperationOnPhaseLECA( op : (LittleEndian => () : Controlled, Adjoint ), target : PhaseLittleEndian ) : () {
         body {
             let targetLE = LittleEndian(target);

--- a/Samples/AdiabaticIsing/AdiabaticIsing.qs
+++ b/Samples/AdiabaticIsing/AdiabaticIsing.qs
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Samples.Ising {
     //////////////////////////////////////////////////////////////////////////
 
     /// # Summary
-    /// This uses the Ising model `GeneratorSystem` construced previously to
+    /// This uses the Ising model `GeneratorSystem` constructed previously to
     /// represent the desired interpolated Hamiltonian H(s). This is 
     /// accomplished by choosing an appropriate function for its coefficients.
     ///
@@ -212,7 +212,7 @@ namespace Microsoft.Quantum.Samples.Ising {
 
     /// # Summary
     /// We now allocate qubits to the simulation, implement adiabatic state
-    /// prepartion, and then return the results of spin measurement on each
+    /// preparation, and then return the results of spin measurement on each
     /// site.
     ///
     /// # Input
@@ -321,7 +321,7 @@ namespace Microsoft.Quantum.Samples.Ising {
         let end = EndEvoGen(nSites, jCoupling);
         
         // We choose the time-dependent Trotter–Suzuki decomposition as
-        // our similation algorithm.
+        // our simulation algorithm.
         let timeDependentSimulationAlgorithm = TimeDependentTrotterSimulationAlgorithm(trotterStepSize, trotterOrder);
         
         // The function InterpolatedEvolution uniformly interpolates between the start and the end Hamiltonians.
@@ -330,7 +330,7 @@ namespace Microsoft.Quantum.Samples.Ising {
 
     /// # Summary
     /// We now choose uniform coupling coefficients, allocate qubits to the 
-    /// simulation, implement adiabatic state prepartion, and then return 
+    /// simulation, implement adiabatic state preparation, and then return 
     /// the results of spin measurement on each site.
     ///
     /// # Input

--- a/Samples/BitFlipCode/BitFlipCode.qs
+++ b/Samples/BitFlipCode/BitFlipCode.qs
@@ -56,18 +56,18 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
     // Thus, we can write out our encoder in a very simple form:
 
     /// # Summary
-    /// Given a qubit representing a state to be protected and two auxillary
+    /// Given a qubit representing a state to be protected and two auxiliary
     /// qubits initially in the |0〉 state, encodes the state into the
     /// three-qubit bit-flip code.
     ///
     /// # Input
     /// ## data
     /// A qubit whose state is to be protected.
-    /// ## auxillaryQubits
+    /// ## auxiliaryQubits
     /// Two qubits, initially in the |00〉 state, to be used in protecting
     /// the state of `data`.
     operation EncodeIntoBitFlipCode(
-            data : Qubit, auxillaryQubits : Qubit[]
+            data : Qubit, auxiliaryQubits : Qubit[]
         ) : ()
     {
         body {
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
             // partially applied with the data qubit, to represent
             // a "CNOT-ladder." In this case, the line below
             // applies CNOT₀₁ · CNOT₀₂.
-            ApplyToEachCA(CNOT(data, _), auxillaryQubits);
+            ApplyToEachCA(CNOT(data, _), auxiliaryQubits);
         }
 
         // Since decoding is the adjoint of encoding, we must
@@ -106,15 +106,15 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
     operation CheckBitFlipCodeStateParity() : () {
         body {
             // We start by preparing R_x(π / 3) |0〉 as our
-            // test state, along with two auxillary qubits in the |00〉
+            // test state, along with two auxiliary qubits in the |00〉
             // state that we can use to encode.
             using (register = Qubit[3]) {
                 let data = register[0];
-                let auxillaryQubits = register[1..2];
+                let auxiliaryQubits = register[1..2];
                 Rx(PI() / 3.0, data);
 
                 // Next, we encode our test state.
-                EncodeIntoBitFlipCode(data, auxillaryQubits);
+                EncodeIntoBitFlipCode(data, auxiliaryQubits);
 
                 // At this point, register represents a code block
                 // that protects the state R_x(π / 3) |0〉.
@@ -150,7 +150,7 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
 
                 // To check that we have not disturbed the state, we decode,
                 // rotate back, and assert once more.
-                (Adjoint EncodeIntoBitFlipCode)(data, auxillaryQubits);
+                (Adjoint EncodeIntoBitFlipCode)(data, auxiliaryQubits);
                 (Adjoint Rx)(PI() / 3.0, data);
                 Assert([PauliZ], [data], Zero, "Didn't return to |0〉!");
             }
@@ -191,9 +191,9 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
                 // We start by proceeding the same way as above
                 // in order to obtain the code block state |̅ψ〉.
                 let data = register[0];
-                let auxillaryQubits = register[1..2];
+                let auxiliaryQubits = register[1..2];
                 Rx(PI() / 3.0, data);
-                EncodeIntoBitFlipCode(data, auxillaryQubits);
+                EncodeIntoBitFlipCode(data, auxiliaryQubits);
 
                 // Next, we apply the error that we've been given to the
                 // entire register.
@@ -227,7 +227,7 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
 
                 // To check that we have not disturbed the state, we decode,
                 // rotate back, and assert once more.
-                (Adjoint EncodeIntoBitFlipCode)(data, auxillaryQubits);
+                (Adjoint EncodeIntoBitFlipCode)(data, auxiliaryQubits);
                 (Adjoint Rx)(PI() / 3.0, data);
                 Assert([PauliZ], [data], Zero, "Didn't return to |0〉!");
             }
@@ -319,13 +319,13 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
     {
         body {
             // We once again begin by allocating some qubits to use as data
-            // and auxillary qubits, and by preparing a test state on the
+            // and auxiliary qubits, and by preparing a test state on the
             // data qubit.
             using (register = Qubit[1 + nScratch]) {
                 // We start by proceeding the same way as above
                 // in order to obtain the code block state |̅ψ〉.
                 let data = register[0];
-                let auxillaryQubits = register[1..nScratch];
+                let auxiliaryQubits = register[1..nScratch];
                 Rx(PI() / 3.0, data);
 
                 // We differ this time, however, in how we perform the
@@ -343,7 +343,7 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
                 // blocks.
                 // Note that we also pass data as an array of qubits, to
                 // allow for codes which protect multiple qubits in one block.
-                let codeBlock = encode([data], auxillaryQubits);
+                let codeBlock = encode([data], auxiliaryQubits);
 
                 // Next, we cause an error as usual.
                 error(codeBlock);
@@ -354,7 +354,7 @@ namespace Microsoft.Quantum.Samples.BitFlipCode {
                 Recover(code, fn, codeBlock);
 
                 // Having recovered, we can decode to obtain new qubit arrays
-                // pointing to the decoded data and auxillary qubits.
+                // pointing to the decoded data and auxiliary qubits.
                 let (decodedData, decodedAuxillary) = decode(codeBlock);
 
                 // Finally, we test that our test state was protected.

--- a/Samples/DatabaseSearch/DatabaseSearch.qs
+++ b/Samples/DatabaseSearch/DatabaseSearch.qs
@@ -34,8 +34,8 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
 
     // First, we work out an example of how to construct and apply D without
     // using the canon. We then implement all the steps of Grover search
-    // manually using this databse oracle. Second, we show the amplitude 
-    // amplication libraries provided with the canon can make this task 
+    // manually using this database oracle. Second, we show the amplitude 
+    // amplification libraries provided with the canon can make this task 
     // significantly easier.
 
     //////////////////////////////////////////////////////////////////////////
@@ -138,7 +138,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
     ///
     /// # Input
     /// ## markedQubit
-    /// Qubit that indicats whether database element is marked.
+    /// Qubit that indicates whether database element is marked.
     /// ## databaseRegister
     /// A register of n qubits initially in the |00…0〉 state.
     operation StatePreparationOracle(markedQubit: Qubit, databaseRegister: Qubit[]) : () {
@@ -410,7 +410,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
     // defined above with one major difference -- Its arguments have signature
     // the signature (Int, Qubit[]). Rather than directly passing the marked 
     // qubit to the operation, we instead pass an integer than indexes The
-    // location of the marked qubit in the qubit arrary, which now encompasses
+    // location of the marked qubit in the qubit array, which now encompasses
     // all qubits.  
 
     // Our goal is thus to construct this `StateOracle` oracle type and pass it

--- a/Samples/DatabaseSearch/Program.cs
+++ b/Samples/DatabaseSearch/Program.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch
 
                 successCount += markedQubit == Result.One ? 1 : 0;
 
-                // Print the results of the search every 100 attemps
+                // Print the results of the search every 100 attempts
                 if ((idxAttempt + 1) % 100 == 0)
                 {
 
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch
 
             // Let us investigate the success probability of the quantum search.
             
-            // Wedefine the size `N` = 2^n of the database to searched in terms of 
+            // We define the size `N` = 2^n of the database to searched in terms of 
             // number of qubits `n`. 
             nDatabaseQubits = 6;
             databaseSize = Math.Pow(2.0, nDatabaseQubits);
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch
 
                 successCount += markedQubit == Result.One ? 1 : 0;
 
-                // Print the results of the search every 10 attemps
+                // Print the results of the search every 10 attempts
                 if ((idxAttempt + 1) % 10 == 0)
                 {
                     var empiricalSuccessProbability = Math.Round((double)successCount / ((double)idxAttempt + 1), 3);
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch
 
                 successCount += markedQubit == Result.One ? 1 : 0;
 
-                // Print the results of the search every 1 attemps
+                // Print the results of the search every 1 attempt
                 if ((idxAttempt + 1) % 1 == 0)
                 {
                     var empiricalSuccessProbability = Math.Round((double)successCount / ((double)idxAttempt + 1), 3);

--- a/Samples/H2SimulationCmdLine/Operation.qs
+++ b/Samples/H2SimulationCmdLine/Operation.qs
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation {
     }
 
     /// # Summary
-    /// Given an index, returns a description of the correponding
+    /// Given an index, returns a description of the corresponding
     /// term in the Hamiltonian for H₂. Each term is described by
     /// a pair of integer arrays representing a sparse Pauli operator.
     ///
@@ -211,7 +211,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation {
 
     /// # Summary
     /// We now provide Canon's Hamiltonian simulation
-    /// functions with the above representaiton to automatically
+    /// functions with the above representation to automatically
     /// decompose the H₂ Hamiltonian into an appropriate operation
     /// that we can apply to qubits as we please.
     operation H2TrotterStep(idxBondLength : Int, trotterOrder: Int, trotterStepSize: Double, qubits: Qubit[]): () {

--- a/Samples/H2SimulationCmdLine/Program.cs
+++ b/Samples/H2SimulationCmdLine/Program.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation
                 // step size of 1.
                 //
                 // The result of calling H2EstimateEnergyRPE is a Double, so we can minimize over
-                // that to deal with the possibility that we accidently entered into the excited
+                // that to deal with the possibility that we accidentally entered into the excited
                 // state instead of the ground state of interest.
                 Func<int, Double> estAtBondLength = (idx) => Enumerable.Min(
                     from idxRep in Enumerable.Range(0, 3)

--- a/Samples/H2SimulationGUI/H2SimulationOperations.qs
+++ b/Samples/H2SimulationGUI/H2SimulationOperations.qs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation {
     }
 
     /// # Summary
-    /// Given an index, returns a description of the correponding
+    /// Given an index, returns a description of the corresponding
     /// term in the Hamiltonian for H₂. Each term is described by
     /// a pair of integer arrays representing a sparse Pauli operator.
     ///
@@ -210,7 +210,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation {
 
     /// # Summary
     /// We now provide Canon's Hamiltonian simulation
-    /// functions with the above representaiton to automatically
+    /// functions with the above representation to automatically
     /// decompose the H₂ Hamiltonian into an appropriate operation
     /// that we can apply to qubits as we please.
     operation H2TrotterStep(idxBondLength : Int, trotterOrder: Int, trotterStepSize: Double, qubits: Qubit[]): () {

--- a/Samples/H2SimulationGUI/Program.cs
+++ b/Samples/H2SimulationGUI/Program.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Samples.H2Simulation
                 // step size of 1.
                 //
                 // The result of calling H2EstimateEnergyRPE is a Double, so we can minimize over
-                // that to deal with the possibility that we accidently entered into the excited
+                // that to deal with the possibility that we accidentally entered into the excited
                 // state instead of the ground state of interest.
                 Func<int, Double> estAtBondLength = (idx) => Enumerable.Min(
                     from idxRep in Enumerable.Range(0, 3)

--- a/Samples/HubbardSimulation/HubbardSimulation.qs
+++ b/Samples/HubbardSimulation/HubbardSimulation.qs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Samples.Hubbard {
     //////////////////////////////////////////////////////////////////////////
     
     // In this example, we will show how to simulate the time evolution of
-    // a 1D Hubbard model with `n` sitess. Let `i` be the site index, 
+    // a 1D Hubbard model with `n` sites. Let `i` be the site index, 
     // `s` = 1,0 be the spin index, where 0 is up and 1 is down. t be the 
     // hopping coefficient, U the repulsion coefficient, and aᵢₛ the fermionic 
     // annihilation operator on the fermion indexed by {i,s}. The Hamiltonian 
@@ -31,10 +31,10 @@ namespace Microsoft.Quantum.Samples.Hubbard {
 
     // Energy estimation requires an input state with non-zero overlap with 
     // the ground state, and we use the anti-ferromagnetic state with 
-    // alternating  spins for this purpuse. 
+    // alternating spins for this purpose. 
 
     // The Hubbard Hamiltonian is composed of Fermionic operators which act on
-    // Fermions and satify anti-commutation rules
+    // Fermions and satisfy anti-commutation rules
     //
     // {aⱼ, aₖ} = 0, {a†ⱼ, aₖ†} = 0, {aⱼ, aₖ†} = δⱼₖ.
     //
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.Samples.Hubbard {
     // assuming that j > k.
 
     // Other possible mapping exist, but we do not consider them further here.
-    // Implementing the Jodan-Wigner transform requires us to define a 
+    // Implementing the Jordan-Wigner transform requires us to define a 
     // canonical ordering between the Fermion indices {is} and
     // the qubit index. Let the fermion site be indexed by the qubit i + n*s
  

--- a/Samples/IntegerFactorization/Shor.qs
+++ b/Samples/IntegerFactorization/Shor.qs
@@ -211,14 +211,14 @@ namespace Microsoft.Quantum.Samples.IntegerFactorization
 
                 // Allocate qubits for the superposition of eigenstates of 
                 // the oracle that is used in period finding
-                using( eignestateRegister = Qubit[bitsize]  ) {
+                using( eigenstateRegister = Qubit[bitsize]  ) {
 
-                    // Initialize eignestateRegister to 1 which is a superposition of 
+                    // Initialize eigenstateRegister to 1 which is a superposition of 
                     // the eigenstates we are estimating the phases of. 
                     // We first interpret the register as encoding unsigned integer
                     // in little endian encoding.
-                    let eignestateRegisterLE = LittleEndian(eignestateRegister);
-                    InPlaceXorLE(1,eignestateRegisterLE);
+                    let eigenstateRegisterLE = LittleEndian(eigenstateRegister);
+                    InPlaceXorLE(1,eigenstateRegisterLE);
 
                     // An oracle of type Microsoft.Quantum.Canon.DiscreteOracle 
                     // that we are going to use with phase estimation methods below.
@@ -234,7 +234,7 @@ namespace Microsoft.Quantum.Samples.IntegerFactorization
                         let phase = RobustPhaseEstimation(
                             bitsPrecision, 
                             oracle,
-                            eignestateRegisterLE
+                            eigenstateRegisterLE
                             );
                         
                         // Compute the numerator k of dyadic fraction k/2^bitsPrecision 
@@ -258,7 +258,7 @@ namespace Microsoft.Quantum.Samples.IntegerFactorization
 
                             QuantumPhaseEstimation(
                                 oracle,
-                                eignestateRegisterLE,
+                                eigenstateRegisterLE,
                                 dyadicFractionNumeratorBE);
 
                             // Directly measure the numerator k of dyadic fraction k/2^bitsPrecision 
@@ -270,7 +270,7 @@ namespace Microsoft.Quantum.Samples.IntegerFactorization
 
                     // Return all the qubits used for oracle's eigenstate back to 0 state
                     // using Microsoft.Quantum.Canon.ResetAll
-                    ResetAll(eignestateRegister);
+                    ResetAll(eigenstateRegister);
                 }
 
                 // Sometimes we might measure all zeros state in Phase Estimation.

--- a/Samples/IsingPhaseEstimation/IsingPhaseEstimation.qs
+++ b/Samples/IsingPhaseEstimation/IsingPhaseEstimation.qs
@@ -18,11 +18,11 @@ namespace Microsoft.Quantum.Samples.Ising {
     // The iterative phase estimation algorithm discussed in 
     // `PhaseEstimationSample` is one of many possible variants. The 
     // algorithm there is based on an adaptive sequence of measurements that 
-    // requires a unitary orcale that can be exponentiated by arbitrary
+    // requires a unitary oracle that can be exponentiated by arbitrary
     // real numbers. In our case, we restrict the oracle to be just integer 
     // powers of a single Trotter time step. Thus one compatible choice here 
     // is the Robust phase estimation algorithm, which also happens to be non-
-    /// adaptive, and provides a instructive constrasting implementation.
+    /// adaptive, and provides a instructive contrasting implementation.
 
     // We provide two solutions. 
     // In the first solution, we manually construct and put together all the 

--- a/Samples/IsingPhaseEstimation/Program.cs
+++ b/Samples/IsingPhaseEstimation/Program.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Samples.Ising
                 {
                     // As usual, the Q# operation IsingEstimateEnergy is
                     // represented by a C# class with a static Run method
-                    // which calls the Q# operation asychronously and returns
+                    // which calls the Q# operation asynchronously and returns
                     // a Task object. To wait for the operation to complete,
                     // we can get the Result property of the returned Task.
                     var data = IsingEstimateEnergy.Run(

--- a/Samples/Measurement/Driver.cs
+++ b/Samples/Measurement/Driver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.Samples.Measurement
             // returns a (Result, Result), one for each qubit; let's print
             // out a few such measurements.
 
-            foreach (var idxMeasurment in Enumerable.Range(0, 8))
+            foreach (var idxMeasurement in Enumerable.Range(0, 8))
             {
                 var results = MeasurementTwoQubits.Run(sim).Result;
                 System.Console.WriteLine($"Measured HH|00〉 and observed {results}.");
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.Samples.Measurement
             // unlike in the previous example, the two Result values are
             // always the same.
 
-            foreach (var idxMeasurment in Enumerable.Range(0, 8))
+            foreach (var idxMeasurement in Enumerable.Range(0, 8))
             {
                 var results = MeasurementBellBasis.Run(sim).Result;
                 System.Console.WriteLine($"Measured CNOT₀₁ · H |00〉 and observed {results}.");

--- a/Samples/OpenQasm/Driver.cs
+++ b/Samples/OpenQasm/Driver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.Samples.OpenQasm
     class Driver
     {
         /// <summary>
-        /// Sample to show that one can substitue the operation factory 
+        /// Sample to show that one can substitute the operation factory 
         /// to run on different types of machines.
         /// </summary>
         /// <param name="args"></param>

--- a/Samples/OpenQasm/OpenQasmDriver.cs
+++ b/Samples/OpenQasm/OpenQasmDriver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Quantum.Samples.OpenQasm
     /// <summary>
     /// Quick and dirty Simulatorbase to write OpenQASM 2.0
     /// Just enough to show that it would work
-    /// Please don't put this in production until its fully engineerd.
-    /// This code could eat your cat. So imagine what schrodinger has to say about that one.
+    /// Please don't put this in production until its fully engineered.
+    /// This code could eat your cat. So imagine what Schrodinger has to say about that one.
     /// </summary>
     public abstract class OpenQasmDriver : SimulatorBase
     {
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Samples.OpenQasm
         }
 
         /// <summary>
-        /// Ingnored becuase this machine doesn't have it. And we recycle qubits anyway
+        /// Ignored because this machine doesn't have it. And we recycle qubits anyway
         /// </summary>
         public class QSimReset : Reset
         {

--- a/Samples/OpenQasmReader.Tests/End2EndTest.cs
+++ b/Samples/OpenQasmReader.Tests/End2EndTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
             var dummyInclude = Path.Combine(Path.GetTempPath(), CommonOpenQasmIncludeFile);
             try
             {
-                //Write OpenQuasm program 
+                //Write OpenQasm program 
                 File.WriteAllText(inputFile, input);
                 File.WriteAllText(dummyInclude, "gate cx a,b { CX a,b; }");
 

--- a/Samples/OpenQasmReader.Tests/ParseApplicationTest.cs
+++ b/Samples/OpenQasmReader.Tests/ParseApplicationTest.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseGateDefintionTest()
+        public void ParseGateDefinitionTest()
         {
             var input = "gate mygate q { H q;}";
 
@@ -128,7 +128,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseIfDefintionTest()
+        public void ParseIfDefinitionTest()
         {
             var input = "if (c0 == 1) z q[2];";
 
@@ -164,7 +164,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseMeasureDefintionTest()
+        public void ParseMeasureDefinitionTest()
         {
             var input = "measure q[0] -> c0[0];";
 
@@ -204,7 +204,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseMeasureMultipleDefintionTest()
+        public void ParseMeasureMultipleDefinitionTest()
         {
             var input = "measure q[0] -> c0[0];measure q[1] -> c0[1];measure q[2] -> c0[2];";
 
@@ -244,7 +244,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseMeasureImplicitQubitDefintionTest()
+        public void ParseMeasureImplicitQubitDefinitionTest()
         {
             var input = "measure q[0]; H q[1];";
 
@@ -286,7 +286,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void ParseMeasureImplicitQubitExpansionDefintionTest()
+        public void ParseMeasureImplicitQubitExpansionDefinitionTest()
         {
             var input = "measure q; H p[1];";
 

--- a/Samples/OpenQasmReader.Tests/ParseConditionTest.cs
+++ b/Samples/OpenQasmReader.Tests/ParseConditionTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         /// Helper function top execute ParseCalculation Method
         /// </summary>
         /// <param name="input">Test file</param>
-        /// <param name="cRegs">Traditonal register</param>
+        /// <param name="cRegs">Traditional register</param>
         /// <param name="endmarkers">Markers to stop on</param>
         /// <returns>resultstring</returns>
         private static string ParseCondition(string input, Dictionary<string,int> cRegs, params string[] endmarkers)

--- a/Samples/OpenQasmReader.Tests/TokenizerTest.cs
+++ b/Samples/OpenQasmReader.Tests/TokenizerTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void CommentsRecognizeUnixLinendingResultsTokens()
+        public void CommentsRecognizeUnixLineEndingResultsTokens()
         {
             var input = "before\n//H\nafter";
             string[] result = null;
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader.Tests
         }
 
         [Fact]
-        public void CommentsRecognizeWindowsLinendingResultsTokens()
+        public void CommentsRecognizeWindowsLineEndingResultsTokens()
         {
             var input = "before\r\n//H\r\nafter";
             string[] result = null;

--- a/Samples/OpenQasmReader/Parser.cs
+++ b/Samples/OpenQasmReader/Parser.cs
@@ -13,7 +13,7 @@ using System.Text;
 namespace Microsoft.Quantum.Samples.OpenQasmReader
 {
     /// <summary>
-    /// A quick and simple qasm parser and Q# generator which was hand roled to remain under MIT license
+    /// A quick and simple qasm parser and Q# generator which was hand rolled to remain under MIT license
     /// </summary>
     public class Parser
     {
@@ -81,10 +81,10 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         }
 
         /// <summary>
-        /// Parses the Qasm application and componenents
+        /// Parses the Qasm application and components
         /// </summary>
         /// <param name="token">Current token the tokenizer is on to parse</param>
-        /// <param name="cRegs">Cassical registers defined</param>
+        /// <param name="cRegs">Classical registers defined</param>
         /// <param name="qRegs">Quantum registers defined</param>
         /// <param name="path">Directory the qasm is located in (mostly for include purposes)</param>
         /// <param name="inside">Stream to write within the current operation being parsed</param>
@@ -195,7 +195,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         {
             token.MoveNext();
             token.MoveNext();
-            var condition = ParseCondition(token, cRegs, CLOSE_PARANTHESES);
+            var condition = ParseCondition(token, cRegs, CLOSE_PARENTHESES);
             Indent(inside);
             inside.AppendFormat("if({0}){{\n", condition);
             IndentLevel++;
@@ -232,12 +232,12 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
             string result = null;
             while (depth != 0 || !(endmarker.Any(marker => marker.Equals(token.Current))))
             {
-                if (token.Current.Equals(OPEN_PARANTHESES))
+                if (token.Current.Equals(OPEN_PARENTHESES))
                 {
                     depth++;
                     result += token.Current;
                 }
-                else if (token.Current.Equals(CLOSE_PARANTHESES))
+                else if (token.Current.Equals(CLOSE_PARENTHESES))
                 {
                     depth--;
                     result += token.Current;
@@ -264,7 +264,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         /// </summary>
         /// <param name="token">Current token the tokenizer is on to parse</param>
         /// <param name="cRegs">Classical registers defined</param>
-        /// <param name="path">Directory the qasm is located in (mostly for inlcude purposes)</param>
+        /// <param name="path">Directory the qasm is located in (mostly for include purposes)</param>
         private static void ParseClassicalRegister(IEnumerator<string> token, Dictionary<string, int> cRegs, StringBuilder inside)
         {
             token.MoveNext();
@@ -299,19 +299,19 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
                 {
                     continue;
                 }
-                else if (token.Current.Equals(CLOSE_PARANTHESES))
+                else if (token.Current.Equals(CLOSE_PARENTHESES))
                 {
                     withinParentheses = false;
                 }
                 else if (withinParentheses)
                 {
-                    doubles.Add(ParseCalculation(token, COMMA, CLOSE_PARANTHESES));
-                    if (token.Current.Equals(CLOSE_PARANTHESES))
+                    doubles.Add(ParseCalculation(token, COMMA, CLOSE_PARENTHESES));
+                    if (token.Current.Equals(CLOSE_PARENTHESES))
                     {
                         withinParentheses = false;
                     }
                 }
-                else if (token.Current.Equals(OPEN_PARANTHESES))
+                else if (token.Current.Equals(OPEN_PARENTHESES))
                 {
                     withinParentheses = true;
                 }
@@ -579,19 +579,19 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
                 {
                     continue;
                 }
-                else if (token.Current.Equals(CLOSE_PARANTHESES))
+                else if (token.Current.Equals(CLOSE_PARENTHESES))
                 {
                     withinParentheses = false;
                 }
                 else if (withinParentheses)
                 {
-                    doubles.Add(ParseCalculation(token, COMMA, CLOSE_PARANTHESES));
-                    if (token.Current.Equals(CLOSE_PARANTHESES))
+                    doubles.Add(ParseCalculation(token, COMMA, CLOSE_PARENTHESES));
+                    if (token.Current.Equals(CLOSE_PARENTHESES))
                     {
                         withinParentheses = false;
                     }
                 }
-                else if (token.Current.Equals(OPEN_PARANTHESES))
+                else if (token.Current.Equals(OPEN_PARENTHESES))
                 {
                     withinParentheses = true;
                 }
@@ -615,7 +615,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         /// Returns the input string with the first character converted to uppercase, or mutates any nulls passed into string.Empty
         /// </summary>
         /// <param name="s">Current string to be converted</param>
-        /// <returns>Same string with the first letter capatalized (or an empty string if not posible)</returns>
+        /// <returns>Same string with the first letter capitalized (or an empty string if not possible)</returns>
         internal static string FirstLetterToUpperCase(string s)
         {
             if (string.IsNullOrEmpty(s))
@@ -634,7 +634,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         /// <param name="token">Current token the tokenizer is on to parse</param>
         /// <param name="cRegs">Classical registers defined</param>
         /// <param name="qRegs">Quantum registers defined</param>
-        /// <param name="path">Directory the qasm is located in (mostly for inlcude purposes)</param>
+        /// <param name="path">Directory the qasm is located in (mostly for include purposes)</param>
         /// <param name="inside">Stream to write within the current operation being parsed</param>
         /// <param name="outside">Stream to write outside the current operation being parsed (mostly for defining side operations)</param>
         /// <param name="classicalMeasured">Currently measured classical registers (mostly used for output)</param>
@@ -647,7 +647,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
 
             if (qRegs.Any())
             {
-                //Move identation a bit back
+                //Move indentation a bit back
                 IndentLevel--;
             }
 
@@ -712,7 +712,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         {
             token.MoveNext(); //(
             token.MoveNext();
-            var x = ParseCalculation(token, COMMA, CLOSE_PARANTHESES);
+            var x = ParseCalculation(token, COMMA, CLOSE_PARENTHESES);
             token.MoveNext();
             var q = token.Current;
             token.MoveNext(); // ;
@@ -724,7 +724,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
             else
             {
                 // 0,0,0 rotation is the idle
-                // Could have left it out, but people seem to use this as a first test and are supprized when it gets optimized away.
+                // Could have left it out, but people seem to use this as a first test and are surprised when it gets optimized away.
                 Indent(builder);
                 builder.AppendFormat("I({0});\n", q);
             }
@@ -740,11 +740,11 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         {
             token.MoveNext(); //(
             token.MoveNext();
-            var x = ParseCalculation(token, COMMA, CLOSE_PARANTHESES);
+            var x = ParseCalculation(token, COMMA, CLOSE_PARENTHESES);
             token.MoveNext();
-            var y = ParseCalculation(token, COMMA, CLOSE_PARANTHESES);
+            var y = ParseCalculation(token, COMMA, CLOSE_PARENTHESES);
             token.MoveNext();
-            var z = ParseCalculation(token, COMMA, CLOSE_PARANTHESES);
+            var z = ParseCalculation(token, COMMA, CLOSE_PARENTHESES);
             token.MoveNext();
             var q = token.Current;
             token.MoveNext(); // ;
@@ -770,7 +770,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
             if (!written)
             {
                 // 0,0,0 rotation is the idle
-                // Could have left it out, but people seem to use this as a first test and are supprized when it gets optimized away.
+                // Could have left it out, but people seem to use this as a first test and are surprised when it gets optimized away.
                 Indent(builder);
                 builder.AppendFormat("I({0});\n", q);
             }
@@ -788,12 +788,12 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
             string result = null;
             while (depth != 0 || !(endmarker.Any(marker => marker.Equals(token.Current))))
             {
-                if (token.Current.Equals(OPEN_PARANTHESES))
+                if (token.Current.Equals(OPEN_PARENTHESES))
                 {
                     depth++;
                     result += token.Current;
                 }
-                else if (token.Current.Equals(CLOSE_PARANTHESES))
+                else if (token.Current.Equals(CLOSE_PARENTHESES))
                 {
                     depth--;
                     result += token.Current;
@@ -831,7 +831,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         /// <param name="token">Current token the tokenizer is on to parse</param>
         /// <param name="cRegs">Classical registers defined</param>
         /// <param name="qRegs">Quantum registers defined</param>
-        /// <param name="path">Directory the qasm is located in (mostly for inlcude purposes)</param>
+        /// <param name="path">Directory the qasm is located in (mostly for include purposes)</param>
         /// <param name="inside">Stream to write within the current operation being parsed</param>
         /// <param name="outside">Stream to write outside the current operation being parsed (mostly for defining side operations)</param>
         /// <param name="classicalMeasured">Currently measured classical registers (mostly used for output)</param>
@@ -868,7 +868,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         }
 
         /// <summary>
-        /// Tokeinzer to split the stream of the file up in individual tokens
+        /// Tokenizer to split the stream of the file up in individual tokens
         /// </summary>
         /// <param name="stream">Filestream</param>
         /// <returns>Tokens in the code file</returns>
@@ -899,7 +899,7 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
                                 token.Clear();
                             }
                             yield return FORWARD_SLASH;
-                            //Handle the caracter after the slash
+                            //Handle the character after the slash
                             if (char.IsLetterOrDigit(buffer[0]) || buffer[0] == '_' || buffer[0] == '.' || buffer[0] == '[' || buffer[0] == ']')
                             {
                                 token.Append(buffer[0]);
@@ -908,8 +908,8 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
                             {
                                 switch (buffer[0])
                                 {
-                                    case '(': yield return OPEN_PARANTHESES; break;
-                                    case ')': yield return CLOSE_PARANTHESES; break;
+                                    case '(': yield return OPEN_PARENTHESES; break;
+                                    case ')': yield return CLOSE_PARENTHESES; break;
                                     case '{': yield return OPEN_CURLYBRACKET; break;
                                     case '}': yield return CLOSE_CURLYBRACKET; break;
                                     case ',': yield return COMMA; break;
@@ -946,8 +946,8 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
                     }
                     switch (buffer[0])
                     {
-                        case '(': yield return OPEN_PARANTHESES; break;
-                        case ')': yield return CLOSE_PARANTHESES; break;
+                        case '(': yield return OPEN_PARENTHESES; break;
+                        case ')': yield return CLOSE_PARENTHESES; break;
                         case '{': yield return OPEN_CURLYBRACKET; break;
                         case '}': yield return CLOSE_CURLYBRACKET; break;
                         case ',': yield return COMMA; break;
@@ -972,10 +972,10 @@ namespace Microsoft.Quantum.Samples.OpenQasmReader
         }
 
         #region Tokens and other constant Strings
-        private const string OPEN_PARANTHESES = "(";
+        private const string OPEN_PARENTHESES = "(";
         private const string FORWARD_SLASH = "/";
         private const string OPEN_CURLYBRACKET = "{";
-        private const string CLOSE_PARANTHESES = ")";
+        private const string CLOSE_PARENTHESES = ")";
         private const string CLOSE_CURLYBRACKET = "}";
         private const string COMMA = ",";
         private const string POINT_COMMA = ";";

--- a/Samples/PythonInterop/README.md
+++ b/Samples/PythonInterop/README.md
@@ -62,7 +62,7 @@ C:\Users\<username>\AppData\Local\Continuum\anaconda3\envs\qsharp-samples\python
 
 Note that `cmd` is required as `activate` is not currently supported from within PowerShell; if the `(qsharp-samples)` prompt does not appear, you may need to run the above commands from within `cmd`.
 
-In any case, we will not be executing Jupyter inside this enviroment directly, but we will instead rely on `nb_conda` as installed above.
+In any case, we will not be executing Jupyter inside this environment directly, but we will instead rely on `nb_conda` as installed above.
 Thus, you must deactivate `qsharp-samples` to get back to the `root` environment.
 This is done with the `deactivate` command:
 

--- a/Samples/PythonInterop/tomography-sample.ipynb
+++ b/Samples/PythonInterop/tomography-sample.ipynb
@@ -174,7 +174,7 @@
    "metadata": {},
    "source": [
     "In particular, the `qsharp` package provides a `QuantumSimulator` class which wraps the `Microsoft.Quantum.Simulation.Simulators.QuantumSimulator` .NET class provided with the Quantum Development Kit.\n",
-    "This wrapper provides a few useful convienence features that we will use along the way."
+    "This wrapper provides a few useful convenience features that we will use along the way."
    ]
   },
   {
@@ -384,7 +384,7 @@
    "metadata": {},
    "source": [
     "To obtain the output from a Q# operation or function, we must use the `result` function, since outputs are wrapped in .NET asynchronous tasks.\n",
-    "These tasks are wrapped in a future-like object for convienence."
+    "These tasks are wrapped in a future-like object for convenience."
    ]
   },
   {

--- a/Samples/Qiskit/Driver.cs
+++ b/Samples/Qiskit/Driver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.Samples.Qiskit
     class Driver
     {
         /// <summary>
-        /// Sample to show that one can substitue the operation factory 
+        /// Sample to show that one can substitute the operation factory 
         /// to run on different types of machines.
         /// </summary>
         /// <param name="args"></param>

--- a/Samples/Qiskit/QiskitQasmRunner.cs
+++ b/Samples/Qiskit/QiskitQasmRunner.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Quantum.Samples.Qiskit
 {
     /// <summary>
-    /// Quick version to tranfer to python in a real linux environment, because Qiskit doesn't run on the windows python
+    /// Quick version to transfer to python in a real linux environment, because Qiskit doesn't run on the windows python
     /// </summary>
     internal static class QiskitExecutor
     {

--- a/Samples/SimpleAlgorithms/Driver.cs
+++ b/Samples/SimpleAlgorithms/Driver.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Quantum.Samples.SimpleAlgorithms
 
             #endregion
 
-            #region Constant versus Balanced Functions with the Deutsch–Josza Algorithm
+            #region Constant versus Balanced Functions with the Deutsch–Jozsa Algorithm
             // A Boolean function is a function that maps bitstrings to a
             // bit,
             //
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Samples.SimpleAlgorithms
 
             // If we are given a function 𝑓 as a quantum operation 𝑈 |𝑥〉|𝑦〉
             // = |𝑥〉|𝑦 ⊕ 𝑓(𝑥)〉, and are promised that 𝑓 is either constant or
-            // is balanced, then the Deutsch–Josza algorithm decides between
+            // is balanced, then the Deutsch–Jozsa algorithm decides between
             // these cases with a single application of 𝑈.
 
             // In SimpleAlgorithms.qs, we implement this algorithm as

--- a/Samples/SimpleAlgorithms/SimpleAlgorithms.qs
+++ b/Samples/SimpleAlgorithms/SimpleAlgorithms.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Samples.SimpleAlgorithms {
     // Introduction //////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////
 
-    // This sample contains serveral simple quantum algorithms coded in Q#. The 
+    // This sample contains several simple quantum algorithms coded in Q#. The 
     // intent is to highlight the expressive capabilities of the language that 
     // enable it to express quantum algorithms that consist of a short quantum
     // part and classical post-processing that is simple, or in some cases,
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Samples.SimpleAlgorithms {
         return ParityOperationImpl(pattern, _);
     }
 
-    // For convienence, we provide an additional operation with a signature
+    // For convenience, we provide an additional operation with a signature
     // that's easy to call from C#. In particular, we define our new operation
     // to take an Int as input and to return an Int as output, where each
     // Int represents a bitstring using the little endian convention.

--- a/Samples/SimpleIsing/SimpleIsing.qs
+++ b/Samples/SimpleIsing/SimpleIsing.qs
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.Samples.SimpleIsing {
 
     // With this operation in place, we can now decompose evolution
     // under the full Hamiltonian H given above using the Trotter–Suzuki
-    // decomposition. For simplicity, we'll use the first-oder Trotter–Suzuki
+    // decomposition. For simplicity, we'll use the first-order Trotter–Suzuki
     // decomposition; higher orders can be written easily using the flow control
     // and generator representation operations provided with the canon.
 
@@ -109,7 +109,7 @@ namespace Microsoft.Quantum.Samples.SimpleIsing {
                 // and provide specific values for each.
                 // Transverse field:
                 let hx = 1.0;
-                // Longitiduinal field:
+                // Longitudinal field:
                 let hz = 0.5;
                 // Ising coupling:
                 let J = 1.0;
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.Samples.SimpleIsing {
                     for (idxSite in 0..nSites - 1) {
                         // Evolve under the transverse field for φx ≔ (1 - s) hx dt.
                         Rx(- 2.0 * (1.0 - sweepParameter) * hx * dt, qs[idxSite]);
-                        // Evolve under the longitiduinal field for φz ≔ s hz dt.
+                        // Evolve under the longitudinal field for φz ≔ s hz dt.
                         Rz(- 2.0 * sweepParameter * hz * dt, qs[idxSite]);
                         // If we aren't the last qubit, evolve under the Ising
                         // coupling for φJ ≔ s J dt.

--- a/Samples/Teleportation/TeleportationSample.qs
+++ b/Samples/Teleportation/TeleportationSample.qs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Examples.Teleportation {
         body {
 
             using (register = Qubit[1]) {
-                // Ask for an auxillary qubit that we can use to prepare
+                // Ask for an auxiliary qubit that we can use to prepare
                 // for teleportation.
                 let here = register[0];
             

--- a/Samples/UnitTesting/CCNOTCircuitsMetrics.cs
+++ b/Samples/UnitTesting/CCNOTCircuitsMetrics.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting
             QCTraceSimulator sim = MetricCalculationUtils.GetSimulatorForMetricsCalculation();
 
             // Run tests against trace simulator to collect metrics
-            var result1 = CCNOTCiruitsTest.Run(sim).Result;
+            var result1 = CCNOTCircuitsTest.Run(sim).Result;
 
             // Let us check that number of T gates in all the circuits is as expected
             string Tcount = PrimitiveOperationsGroupsNames.T;

--- a/Samples/UnitTesting/CCNOTCircuitsTests.qs
+++ b/Samples/UnitTesting/CCNOTCircuitsTests.qs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # Summary 
     /// This operation tests correctness of the implementation of Doubly Controlled X gates
     /// also known as Toffoli gates.
-    operation CCNOTCiruitsTest() : () {
+    operation CCNOTCircuitsTest() : () {
         body {
             
             //  List of pairs of operations (expected,actual) to be tested up to a phase

--- a/Samples/UnitTesting/MultiControlledNOTMetrics.cs
+++ b/Samples/UnitTesting/MultiControlledNOTMetrics.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting
             string allocatedQubits = MetricsNames.WidthCounter.ExtraWidth;
 
             // Get the number of qubits borrowed by the MultiControlledXBorrow
-            double numBorowed1 = 
+            double numBorrowed1 = 
                 sim.GetMetric<MultiControlledXBorrow, MultiControlledNotWithDirtyQubitsMetrics>(
                     borrowedQubits);
 
@@ -53,11 +53,11 @@ namespace Microsoft.Quantum.Samples.UnitTesting
                 sim.GetMetric<MultiControlledXBorrow, MultiControlledNotWithDirtyQubitsMetrics>(
                     allocatedQubits);
 
-            Assert.Equal(numberOfControlQubits - 2, numBorowed1);
+            Assert.Equal(numberOfControlQubits - 2, numBorrowed1);
             Assert.Equal(0, numAllocated1);
 
             // Get the number of qubits borrowed by the MultiControlledXClean
-            double numBorowed2 =
+            double numBorrowed2 =
                 sim.GetMetric<MultiControlledXClean, MultiControlledNotWithDirtyQubitsMetrics>(
                     borrowedQubits);
 
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting
                 allocatedQubits);
 
             Assert.Equal(numberOfControlQubits - 2, numAllocated2);
-            Assert.Equal(0, numBorowed2);
+            Assert.Equal(0, numBorrowed2);
         }
     }
 }

--- a/Samples/UnitTesting/MultiTargetCNOTTests.qs
+++ b/Samples/UnitTesting/MultiTargetCNOTTests.qs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
 
     /// # Summary 
     /// Tests correctness of MultiTargetMultiNot implementations
-    operation MultiTartgetMultiControlledNotTest() : () {
+    operation MultiTargetMultiControlledNotTest() : () {
         body {
             //  list of the operations to test in format (actual,expected)
             let testList = [

--- a/Samples/UnitTesting/QuantumSimulatorTestTargets.cs
+++ b/Samples/UnitTesting/QuantumSimulatorTestTargets.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting
             try
             {
                 // Generate seed based on name of testclass, so testruns are more deterministic
-                // but we don't always use the same seed througout the solution.
+                // but we don't always use the same seed throughout the solution.
                 byte[] bytes = Encoding.Unicode.GetBytes(operationDescription.fullClassName);
                 byte[] hash = hashMethod.ComputeHash(bytes);
                 uint seed = BitConverter.ToUInt32(hash, 0);

--- a/Samples/UnitTesting/SuperdenseCoding.qs
+++ b/Samples/UnitTesting/SuperdenseCoding.qs
@@ -55,9 +55,9 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
                 // "Send" qubit to B and let B decode two bits.
                 let ( decodedBit1, decodedBit2 ) = SuperdenseDecode(qubit1,qubit2);
 
-                // Now test if the bits were transfered correctly.
-                AssertBoolEqual(bit1, decodedBit1, "bit1 should be transfered correctly" );
-                AssertBoolEqual(bit2, decodedBit2, "bit2 should be transfered correctly" );
+                // Now test if the bits were transferred correctly.
+                AssertBoolEqual(bit1, decodedBit1, "bit1 should be transferred correctly" );
+                AssertBoolEqual(bit2, decodedBit2, "bit2 should be transferred correctly" );
 
                 // Make sure that we return qubits back in 0 state.
                 ResetAll(qubits);


### PR DESCRIPTION
I have passed each file in the repo through [scspell](https://pypi.org/project/scspell3k/) and corrected any obvious typos that have appeared. In some instances function names/variable changes were modified, but if preferred I can undo these.