### PR TITLE
Order finding quantum algorithm

### DIFF
--- a/Samples/src/OrderFinding/OrderFinding.csproj
+++ b/Samples/src/OrderFinding/OrderFinding.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <StartupObject>Microsoft.Quantum.Samples.OrderFinding.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReversibleLogicSynthesis\ReversibleLogicSynthesis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.3.1811.203-preview" />
+    <PackageReference Include="Microsoft.Quantum.Canon" Version="0.3.1811.203-preview" />
+  </ItemGroup>
+</Project>

--- a/Samples/src/OrderFinding/OrderFinding.qs
+++ b/Samples/src/OrderFinding/OrderFinding.qs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Samples.OrderFinding {
 
     /// # Summary
     /// Given a permutation π, this function returns the
-    /// square of the permutation π².
+    /// square of π, i.e., the permutation π².
     ///
     /// # Input
     /// ## perm
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Samples.OrderFinding {
     }
 
     /// # Summary
-    /// Order Finding algorithm as described in [1]
+    /// Implementes the Order Finding algorithm as described in L.M.K. Vandersypen et al., PRL 85, 5452, 2000 (https://arxiv.org/abs/quant-ph/0007017).
     ///
     /// The input permutation has 2ⁿ elements.  Then the quantum circuit
     /// has 2n + 1 qubits, where the n + 1 upper qubits are used to create
@@ -50,7 +50,6 @@ namespace Microsoft.Quantum.Samples.OrderFinding {
     /// ## index
     /// Index of permutation
     ///
-    /// [1] L.M.K. Vandersypen et al., PRL 85, 5452, 2000 (https://arxiv.org/abs/quant-ph/0007017)
     operation OrderFinding(perm : Int[], input : Int) : Int {
         body (...) {
             let n = BitSize(Length(perm) - 1);

--- a/Samples/src/OrderFinding/OrderFinding.qs
+++ b/Samples/src/OrderFinding/OrderFinding.qs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Samples.OrderFinding {
+    open Microsoft.Quantum.Extensions.Math;
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Samples.ReversibleLogicSynthesis;
+
+    /// # Summary
+    /// Given a permutation π, this function returns the
+    /// square of the permutation π².
+    ///
+    /// # Input
+    /// ## perm
+    /// A permutation with elements 0, ..., n - 1
+    ///
+    /// # Output
+    /// The square of the input permutation
+    ///
+    /// # Example
+    /// ```Q#
+    /// Square([1; 2; 3; 0]); // [2; 3; 0; 1]
+    /// Square([2; 3; 0; 1]); // [0; 1; 2; 3]
+    /// ```
+    function Square(perm : Int[]) : Int[] {
+        mutable sq_perm = new Int[Length(perm)];
+        for (i in 0..Length(perm) - 1) {
+            set sq_perm[i] = perm[perm[i]];
+        }
+        return sq_perm;
+    }
+
+    /// # Summary
+    /// Order Finding algorithm as described in [1]
+    ///
+    /// The input permutation has 2ⁿ elements.  Then the quantum circuit
+    /// has 2n + 1 qubits, where the n + 1 upper qubits are used to create
+    /// a superposition over 2ⁿ⁺¹ numbers, which represent the exponents
+    /// of the permutation.  The permutation is called n + 1 times for exponents
+    /// 2⁰, 2¹, ..., 2ⁿ on the lower n qubits.  For each exponent, we update the
+    /// permutation and compute a quantum circuit using reversible logic synthesis
+    /// from the namespace `Microsoft.Quantum.Samples.ReversibleLogicSynthesis`.
+    /// Finally, a QFT is applied to the upper qubits.
+    ///
+    /// # Input
+    /// ## perm
+    /// The input permutation
+    ///
+    /// ## index
+    /// Index of permutation
+    ///
+    /// [1] L.M.K. Vandersypen et al., PRL 85, 5452, 2000 (https://arxiv.org/abs/quant-ph/0007017)
+    operation OrderFinding(perm : Int[], input : Int) : Int {
+        body (...) {
+            let n = BitSize(Length(perm) - 1);
+            mutable result = 0;
+            mutable perm_int = perm;
+
+            using (qubits = Qubit[2 * n + 1]) {
+                let top_qubits = qubits[0..n];
+                let bot_qubits = qubits[n + 1..2 * n];
+
+                ApplyToEach(H, top_qubits);
+
+                for (i in 0..n) {
+                    Controlled (PermutationOracle(perm_int, TBS, _))([qubits[n - i]], bot_qubits);
+                    set perm_int = Square(perm_int);
+                }
+
+                QFT(BigEndian(top_qubits));
+
+                set result = MeasureIntegerBE(BigEndian(top_qubits));
+
+                ResetAll(qubits);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Samples/src/OrderFinding/Program.cs
+++ b/Samples/src/OrderFinding/Program.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Quantum.Samples.OrderFinding
 {
     /// <summary>
     /// This class holds a permutation π and allows to compute its
-    /// order in various different ways (exact, guess classically,
-    /// guess with quantum)
+    /// order in various different ways (exactly, classical guess, 
+    /// and quantum guess)
     /// </summary>
     class Permutation
     {
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Samples.OrderFinding
         }
 
         /// <summary>
-        /// Returns the exact order (length) of the cycle that contains given index
+        /// Returns the exact order (length) of the cycle that contains a given index
         /// <summary>
         public int ComputeOrder(int index)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Samples.OrderFinding
         }
 
         /// <summary>
-        /// Guesses the order (classically) for cycle that contains index
+        /// Guesses the order (classically) for cycle that contains a given index
         ///
         /// The algorithm computes π³(index).  If the result is index, it
         /// returns 1 or 3 with probability 50% each, otherwise, it
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Samples.OrderFinding
         }
 
         /// <summary>
-        /// Guesses order classically for shots times, and returns the percentage for each order that was returned.
+        /// Guesses the order classically by applying estimate `shots` many times and returning the percentage for each order that was returned.
         /// </summary>
         public IEnumerable<(int order, double percentage)> GuessOrderClassical(int index)
         {

--- a/Samples/src/OrderFinding/Program.cs
+++ b/Samples/src/OrderFinding/Program.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Quantum.Samples.OrderFinding
+{
+    /// <summary>
+    /// This class holds a permutation π and allows to compute its
+    /// order in various different ways (exact, guess classically,
+    /// guess with quantum)
+    /// </summary>
+    class Permutation
+    {
+        /// <summary>
+        /// The permutation object is constructed with a permutation π and
+        /// a number of shots for repetitions when guessing.
+        /// <param name="permutation">Permutation π over 4 elements 0, 1, 2, 3</param>
+        /// <param name="shots">Number of repetitions when guessing</param>
+        /// </summary>
+        public Permutation(List<int> permutation, int shots = 1024)
+        {
+            _p = permutation;
+            _shots = shots;
+        }
+
+        /// <summary>
+        /// Returns the exact order (length) of the cycle that contains given index
+        /// <summary>
+        public int ComputeOrder(int index)
+        {
+            int order = 1, cur = index;
+            while (index != _p[cur])
+            {
+                ++order;
+                cur = _p[cur];
+            }
+            return order;
+        }
+
+        /// <summary>
+        /// Guesses the order (classically) for cycle that contains index
+        ///
+        /// The algorithm computes π³(index).  If the result is index, it
+        /// returns 1 or 3 with probability 50% each, otherwise, it
+        /// returns 2 or 4 with probability 50% each. 
+        /// <summary>
+        private int GuessOrderClassicalOne(int index)
+        {
+            if (_p[_p[_p[index]]] == index)
+            {
+                return _rnd.Next(2) == 0 ? 1 : 3;
+            }
+            else
+            {
+                return _rnd.Next(2) == 0 ? 2 : 4;
+            }
+        }
+
+        /// <summary>
+        /// Guesses order classically for shots times, and returns the percentage for each order that was returned.
+        /// </summary>
+        public IEnumerable<(int order, double percentage)> GuessOrderClassical(int index)
+        {
+            return Enumerable.Range(0, _shots).Select(_ => GuessOrderClassicalOne(index)).GroupBy(n => n, (n, list) => (n, list.Count() / (double)_shots));
+        }
+
+        /// <summary>
+        /// The quantum estimation calls the quantum algorithm in the Q# file which computes the permutation
+        /// πⁱ(input) where i is a superposition of all values from 0 to 7.  The algorithm then uses QFT to
+        /// find a period in the resulting state.  The result needs to be post-processed to find the estimate.
+        /// <summary>
+        private int GuessOrderQuantumOne(int index)
+        {
+            var result = OrderFinding.Run(_sim, new QArray<long>(_p.ConvertAll(x => (long)x)), (long)index).Result;
+
+            if (result == 0)
+            {
+                var guess = _rnd.NextDouble();
+                if (guess <= 0.5505)
+                {
+                    return 1;
+                }
+                else if (guess <= 0.5505 + 0.1009)
+                {
+                    return 2;
+                }
+                else if (guess <= 0.5505 + 0.1009 + 0.1468)
+                {
+                    return 3;
+                }
+                else
+                {
+                    return 4;
+                }
+            }
+            else if (result % 2 == 1)
+            {
+                return 3;
+            }
+            else if (result == 2 || result == 6)
+            {
+                return 4;
+            }
+            else /* result == 4 */
+            {
+                return 2;
+            }
+        }
+
+        /// <summary>
+        /// Guesses order using Q# for shots times, and returns the percentage for each order that was returned.
+        /// </summary>
+        public IEnumerable<(int order, double percentage)> GuessOrderQuantum(int index)
+        {
+            return Enumerable.Range(0, _shots).Select(_ => GuessOrderQuantumOne(index)).GroupBy(n => n, (n, list) => (n, list.Count() / (double)_shots));
+        }
+
+        public override string ToString() => "[" + String.Join(" ", _p) + "]";
+
+        private readonly List<int> _p;
+        private readonly int _shots;
+        private readonly Random _rnd = new Random();
+        private readonly QuantumSimulator _sim = new QuantumSimulator();
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            /* user input (permutation must have 4 elements) */
+            var perm = new Permutation(new List<int> { 1, 2, 3, 0 });
+            int index = 0;
+
+            /* print some info on the permutation */
+            Console.WriteLine($"Permutation: {perm}");
+            Console.WriteLine($"Find cycle length at index {index}\n");
+
+            /* compute exact order */
+            Console.WriteLine($"Exact order: {perm.ComputeOrder(index)}\n");
+
+            /* guess order classically */
+            Console.WriteLine("Guess classically:");
+            Console.WriteLine(String.Join("\n", perm.GuessOrderClassical(index).Select(x => $"{x.order}: {x.percentage.ToString("P")}")));
+
+            /* guess order with Q# */
+            Console.WriteLine("\nGuess with Q#:");
+            Console.WriteLine(String.Join("\n", perm.GuessOrderQuantum(index).Select(x => $"{x.order}: {x.percentage.ToString("P")}")));
+
+            Console.WriteLine("\nPress Enter to continue...");
+            Console.ReadLine();
+        }
+    }
+}

--- a/Samples/src/OrderFinding/Program.cs
+++ b/Samples/src/OrderFinding/Program.cs
@@ -81,6 +81,9 @@ namespace Microsoft.Quantum.Samples.OrderFinding
             if (result == 0)
             {
                 var guess = _rnd.NextDouble();
+                // the probability distribution is extracted from the second
+                // column (m = 0) in Fig. 2's table on the right-hand side,
+                // in the original and referenced paper.
                 if (guess <= 0.5505)
                 {
                     return 1;

--- a/Samples/src/OrderFinding/README.md
+++ b/Samples/src/OrderFinding/README.md
@@ -1,0 +1,43 @@
+# Order Finding #
+
+This sample uses a quantum algorithm to find the order of a cycle in a permutation.
+It succeeds with a higher probability than the classical best possible strategy.
+A challenge in the algorithm is to find a quantum circuit to realize the input permutation.
+We utilize [reversible logic synthesis](../ReversibleLogicSynthesis) for this task.
+
+The algorithm has been presented by L.M.K. Vandersypen, M. Steffen, G. Breyta, C.S. Yannoni, R. Cleve,
+and I.L. Chuang in [Experimental realization of an order-finding algorithm with an NMR quantum computer](https://doi.org/10.1103/PhysRevLett.85.5452),
+*Phys. Rev. Lett.* **85**, 5452, 2000.
+The quantum algorithm in the Q# file is implemented for permutations over 2ⁿ elements, however, the classical post-processing
+in the C# file is restricted to permutations over 4 elements.
+
+## Running the Sample ##
+
+Open the `QsharpLibraries.sln` solution in Visual Studio and set *Samples / 1. Algorithms / OrderFinding* as the startup project.
+Press Start in Visual Studio to run the sample.
+
+## Manifest ##
+
+- **OrderFinding/**
+  - [OrderFinding.csproj](./OrderFinding.csproj): Main C# project for the example.
+  - [Program.cs](./Program.cs): C# code to call the operations defined in Q# and perform classical post-processing.
+  - [OrderFinding.qs](./OrderFinding.qs): The Q# implementation of the order finding algorithm.
+
+## Example run ##
+
+```
+Permutation: [1 2 3 0]
+Find cycle length at index 0
+
+Exact order: 4
+
+Guess classically:
+2: 50.78%
+4: 49.22%
+
+Guess with Q#:
+4: 55.27%
+2: 25.29%
+1: 15.72%
+3: 3.71%
+```

--- a/Samples/src/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
+++ b/Samples/src/ReversibleLogicSynthesis/ReversibleLogicSynthesis.qs
@@ -332,6 +332,8 @@ namespace Microsoft.Quantum.Samples.ReversibleLogicSynthesis {
         }
         
         adjoint invert;
+        controlled auto;
+        controlled adjoint auto;
     }
     
     


### PR DESCRIPTION
This is an implementation of the order-finding algorithm described in the paper by L.M.K. Vandersypen, M. Steffen, G. Breyta, C.S. Yannoni, R. Cleve, and I.L. Chuang in [Experimental realization of an order-finding algorithm with an NMR quantum computer](https://doi.org/10.1103/PhysRevLett.85.5452), *Phys. Rev. Lett.* **85**, 5452, 2000.

It needs to realize a permutation with different exponents in the quantum circuit. The algorithm makes use of the `PermutationOracle` from the `ReversibleLogicSynthesis` project for this purpose. It also uses `QFT` from the canon.

The quantum algorithm is implemented for general permutation sizes (2ⁿ elements), however, the classical post-processing in the C# file is restricted to permutations over 4 elements.

I needed to make a small update to `PermutationOracle` to allow it to be used as a controlled operation.
