### PR TITLE
Clean up unit testing sample using 0.6 features

### DIFF
--- a/Chemistry/MolecularHydrogen/HydrogenSimulation.qs
+++ b/Chemistry/MolecularHydrogen/HydrogenSimulation.qs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Chemistry.Samples.Hydrogen {
+
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Chemistry.JordanWigner;  
+	open Microsoft.Quantum.Simulation;	
     open Microsoft.Quantum.Characterization;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Chemistry.JordanWigner;  
-	open Microsoft.Quantum.Simulation;	
     
     // We now use the Q# component of the chemistry library to obtain
     // quantum operations that implement real-time evolution by

--- a/Samples/src/UnitTesting/CCNOTCircuits.qs
+++ b/Samples/src/UnitTesting/CCNOTCircuits.qs
@@ -112,23 +112,27 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # References
     /// - [ *Michael A. Nielsen , Isaac L. Chuang*,
     ///     Quantum Computation and Quantum Information ](http://doi.org/10.1017/CBO9780511976667)
-    operation CCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
-        H(target);
-        CNOT(control1, target);
-        Adjoint T(target);
-        CNOT(control2, target);
-        T(target);
-        CNOT(control1, target);
-        Adjoint T(target);
-        CNOT(control2, target);
-        T(target);
-        Adjoint T(control1);
-        CNOT(control2, control1);
-        H(target);
-        Adjoint T(control1);
-        CNOT(control2, control1);
-        T(control2);
-        S(control1);
+    operation CCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Ctl {
+        body (...) {
+            H(target);
+            CNOT(control1, target);
+            Adjoint T(target);
+            CNOT(control2, target);
+            T(target);
+            CNOT(control1, target);
+            Adjoint T(target);
+            CNOT(control2, target);
+            T(target);
+            Adjoint T(control1);
+            CNOT(control2, control1);
+            H(target);
+            Adjoint T(control1);
+            CNOT(control2, control1);
+            T(control2);
+            S(control1);
+        }
+
+        adjoint self;
     }
 
 
@@ -144,22 +148,26 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # See Also
     /// - For the circuit diagram see Figure 7 (a) on
     ///   [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
-    operation CCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
-        Adjoint T(control1);
-        Adjoint T(control2);
-        H(target);
-        CNOT(target, control1);
-        T(control1);
-        CNOT(control2, target);
-        CNOT(control2, control1);
-        T(target);
-        Adjoint T(control1);
-        CNOT(control2, target);
-        CNOT(target, control1);
-        Adjoint T(target);
-        T(control1);
-        H(target);
-        CNOT(control2, control1);
+    operation CCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Ctl {
+        body (...) {
+            Adjoint T(control1);
+            Adjoint T(control2);
+            H(target);
+            CNOT(target, control1);
+            T(control1);
+            CNOT(control2, target);
+            CNOT(control2, control1);
+            T(target);
+            Adjoint T(control1);
+            CNOT(control2, target);
+            CNOT(target, control1);
+            Adjoint T(target);
+            T(control1);
+            H(target);
+            CNOT(control2, control1);
+        }
+
+        adjoint self;
     }
 
 
@@ -248,7 +256,6 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
         //     Microsoft.Quantum.Intrinsic.M, which does is not Adj. Instead, we
         //     explicitly use the "self" generator.
         adjoint self;
-        controlled adjoint self;
     }
 
 
@@ -261,23 +268,27 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// #Recall that ExpFrac used in the circuit below is an exponent of the
     ///  respective multi-qubit Pauli gate times numerator Pi() i /2^{n-1}
     ///  It is a primitive gate implemented by Quantum.Intrinsics
-    operation CCZ1 (qubit1 : Qubit, qubit2 : Qubit, qubit3 : Qubit) : Unit is Adj + Ctl {
-        let register = [qubit1, qubit2, qubit3];
+    operation CCZ1 (qubit1 : Qubit, qubit2 : Qubit, qubit3 : Qubit) : Unit is Ctl {
+        body (...) {
+            let register = [qubit1, qubit2, qubit3];
 
-        // note that CCZ = exp( iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| )
-        // next use |1⟩⟨1| = (I-Z)/2 and write
-        // iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| =
-        //          = iπ/2³(I⊗I⊗I - Z⊗I⊗I - I⊗Z⊗I - I⊗I⊗Z + Z⊗Z⊗I + Z⊗I⊗Z + I⊗Z⊗Z - Z⊗Z⊗Z)
-        // using above we express CCZ as:
-        // exp( iπ/2³I⊗I⊗I )
-        ExpFrac([PauliI, PauliI, PauliI], 1, 3, register);
-        ExpFrac([PauliZ, PauliI, PauliI], -1, 3, register);
-        ExpFrac([PauliI, PauliZ, PauliI], -1, 3, register);
-        ExpFrac([PauliI, PauliI, PauliZ], -1, 3, register);
-        ExpFrac([PauliZ, PauliZ, PauliI], 1, 3, register);
-        ExpFrac([PauliZ, PauliI, PauliZ], 1, 3, register);
-        ExpFrac([PauliI, PauliZ, PauliZ], 1, 3, register);
-        ExpFrac([PauliZ, PauliZ, PauliZ], -1, 3, register);
+            // note that CCZ = exp( iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| )
+            // next use |1⟩⟨1| = (I-Z)/2 and write
+            // iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| =
+            //          = iπ/2³(I⊗I⊗I - Z⊗I⊗I - I⊗Z⊗I - I⊗I⊗Z + Z⊗Z⊗I + Z⊗I⊗Z + I⊗Z⊗Z - Z⊗Z⊗Z)
+            // using above we express CCZ as:
+            // exp( iπ/2³I⊗I⊗I )
+            ExpFrac([PauliI, PauliI, PauliI], 1, 3, register);
+            ExpFrac([PauliZ, PauliI, PauliI], -1, 3, register);
+            ExpFrac([PauliI, PauliZ, PauliI], -1, 3, register);
+            ExpFrac([PauliI, PauliI, PauliZ], -1, 3, register);
+            ExpFrac([PauliZ, PauliZ, PauliI], 1, 3, register);
+            ExpFrac([PauliZ, PauliI, PauliZ], 1, 3, register);
+            ExpFrac([PauliI, PauliZ, PauliZ], 1, 3, register);
+            ExpFrac([PauliZ, PauliZ, PauliZ], -1, 3, register);
+        }
+
+        adjoint self;
     }
 
 
@@ -286,10 +297,14 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// tensor products of Z operators
     /// # Remarks
     /// Uses 7 T gates, 10 CNOTs and two Hadamard gates and has T depth 5
-    operation CCNOT4 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
-        H(target);
-        CCZ1(control1, control2, target);
-        H(target);
+    operation CCNOT4 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Ctl {
+        body (...) {
+            H(target);
+            CCZ1(control1, control2, target);
+            H(target);
+        }
+
+        adjoint self;
     }
 
 }

--- a/Samples/src/UnitTesting/CCNOTCircuits.qs
+++ b/Samples/src/UnitTesting/CCNOTCircuits.qs
@@ -36,21 +36,14 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # Recall that RFrac(P,num, pow, q) applies rotation about Pauli axis P by the fractional
     ///   angle $$num Pi()/ 2^{pow-1}$$
     ///   In this rotations are about Y axis by the angle $$\pm Pi()/4$
-    operation UpToPhaseCCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
-
-        body (...) {
-            RFrac(PauliY, -1, 3, target);
-            CNOT(control1, target);
-            RFrac(PauliY, -1, 3, target);
-            CNOT(control2, target);
-            RFrac(PauliY, 1, 3, target);
-            CNOT(control1, target);
-            RFrac(PauliY, 1, 3, target);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation UpToPhaseCCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        RFrac(PauliY, -1, 3, target);
+        CNOT(control1, target);
+        RFrac(PauliY, -1, 3, target);
+        CNOT(control2, target);
+        RFrac(PauliY, 1, 3, target);
+        CNOT(control1, target);
+        RFrac(PauliY, 1, 3, target);
     }
 
 
@@ -65,19 +58,11 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # See Also
     /// - For the circuit diagram see Equation 9 on
     ///   [ Page 2 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation UpToPhaseCCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
-
-        body (...) {
-            using (ancillas = Qubit[1]) {
-
-                // apply UVU† where U is outer circuit and V is inner circuit
-                WithCA(UpToPhaseCCNOT2OuterCircuit, UpToPhaseCCNOT2InnerCircuit, ancillas + [target, control1, control2]);
-            }
+    operation UpToPhaseCCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        using (auxillary = Qubit()) {
+            // apply UVU† where U is outer circuit and V is inner circuit
+            ApplyWithCA(UpToPhaseCCNOT2OuterCircuit, UpToPhaseCCNOT2InnerCircuit, [auxillary, target, control1, control2]);
         }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
     }
 
 
@@ -85,20 +70,13 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - Used as a part of @"Microsoft.Quantum.Samples.UnitTesting.UpToPhaseCCNOT2"
     /// - For the circuit diagram see Equation 9 on
     ///   [ Page 2 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation UpToPhaseCCNOT2OuterCircuit (qs : Qubit[]) : Unit {
-
-        body (...) {
-            EqualityFactI(Length(qs), 4, "4 qubits are expected");
-            H(qs[1]);
-            CNOT(qs[3], qs[0]);
-            CNOT(qs[1], qs[2]);
-            CNOT(qs[1], qs[3]);
-            CNOT(qs[2], qs[0]);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation UpToPhaseCCNOT2OuterCircuit (qs : Qubit[]) : Unit is Adj + Ctl {
+        EqualityFactI(Length(qs), 4, "4 qubits are expected");
+        H(qs[1]);
+        CNOT(qs[3], qs[0]);
+        CNOT(qs[1], qs[2]);
+        CNOT(qs[1], qs[3]);
+        CNOT(qs[2], qs[0]);
     }
 
 
@@ -106,36 +84,22 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - Used as a part of @"Microsoft.Quantum.Samples.UnitTesting.UpToPhaseCCNOT2"
     /// - For the circuit diagram see Equation 9 on
     ///   [ Page 2 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation UpToPhaseCCNOT2InnerCircuit (qs : Qubit[]) : Unit {
-
-        body (...) {
-            EqualityFactI(Length(qs), 4, "4 qubits are expected");
-            ApplyToEachCA(T, qs[0 .. 1]);
-            ApplyToEachCA(Adjoint T, qs[2 .. 3]);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation UpToPhaseCCNOT2InnerCircuit (qs : Qubit[]) : Unit is Adj + Ctl {
+        EqualityFactI(Length(qs), 4, "4 qubits are expected");
+        ApplyToEachCA(T, qs[0 .. 1]);
+        ApplyToEachCA(Adjoint T, qs[2 .. 3]);
     }
 
 
     /// # Summary
     /// Simple implementation of the CCNOT gate up to phases over
     /// defined as |c₁⟩⊗|c₂⟩⊗|t⟩ ↦ (-i)^(c₁∧c₂) |c₁⟩⊗|c₂⟩⊗|t⊕(c₁∧c₂)⟩.
-    operation UpToPhaseCCNOT3 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
+    operation UpToPhaseCCNOT3 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        // apply |c₁⟩⊗|c₂⟩⊗|t⟩ ↦ |c₁⟩⊗|c₂⟩⊗|t⊕(c₁∧c₂)⟩.
+        CCNOT(control1, control2, target);
 
-        body (...) {
-            // apply |c₁⟩⊗|c₂⟩⊗|t⟩ ↦ |c₁⟩⊗|c₂⟩⊗|t⊕(c₁∧c₂)⟩.
-            CCNOT(control1, control2, target);
-
-            // apply |c₁⟩⊗|c₂⟩ ↦ (-i)^(c₁∧c₂) |c₁⟩⊗|c₂⟩
-            Controlled (Adjoint S)([control1], control2);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+        // apply |c₁⟩⊗|c₂⟩ ↦ (-i)^(c₁∧c₂) |c₁⟩⊗|c₂⟩
+        Controlled (Adjoint S)([control1], control2);
     }
 
 
@@ -148,30 +112,23 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # References
     /// - [ *Michael A. Nielsen , Isaac L. Chuang*,
     ///     Quantum Computation and Quantum Information ](http://doi.org/10.1017/CBO9780511976667)
-    operation CCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
-
-        body (...) {
-            H(target);
-            CNOT(control1, target);
-            Adjoint T(target);
-            CNOT(control2, target);
-            T(target);
-            CNOT(control1, target);
-            Adjoint T(target);
-            CNOT(control2, target);
-            T(target);
-            Adjoint T(control1);
-            CNOT(control2, control1);
-            H(target);
-            Adjoint T(control1);
-            CNOT(control2, control1);
-            T(control2);
-            S(control1);
-        }
-
-        adjoint self;
-        controlled distribute;
-        controlled adjoint self;
+    operation CCNOT1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        H(target);
+        CNOT(control1, target);
+        Adjoint T(target);
+        CNOT(control2, target);
+        T(target);
+        CNOT(control1, target);
+        Adjoint T(target);
+        CNOT(control2, target);
+        T(target);
+        Adjoint T(control1);
+        CNOT(control2, control1);
+        H(target);
+        Adjoint T(control1);
+        CNOT(control2, control1);
+        T(control2);
+        S(control1);
     }
 
 
@@ -187,29 +144,22 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # See Also
     /// - For the circuit diagram see Figure 7 (a) on
     ///   [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
-    operation CCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
-
-        body (...) {
-            Adjoint T(control1);
-            Adjoint T(control2);
-            H(target);
-            CNOT(target, control1);
-            T(control1);
-            CNOT(control2, target);
-            CNOT(control2, control1);
-            T(target);
-            Adjoint T(control1);
-            CNOT(control2, target);
-            CNOT(target, control1);
-            Adjoint T(target);
-            T(control1);
-            H(target);
-            CNOT(control2, control1);
-        }
-
-        adjoint self;
-        controlled distribute;
-        controlled adjoint self;
+    operation CCNOT2 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        Adjoint T(control1);
+        Adjoint T(control2);
+        H(target);
+        CNOT(target, control1);
+        T(control1);
+        CNOT(control2, target);
+        CNOT(control2, control1);
+        T(target);
+        Adjoint T(control1);
+        CNOT(control2, target);
+        CNOT(target, control1);
+        Adjoint T(target);
+        T(control1);
+        H(target);
+        CNOT(control2, control1);
     }
 
 
@@ -223,19 +173,12 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # See Also
     /// - For the circuit diagram see Figure 1 on
     ///   [ Page 3 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation TDepthOneCCNOT (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
+    operation TDepthOneCCNOT (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        using (auxillaryRegister = Qubit[4]) {
 
-        body (...) {
-            using (ancillas = Qubit[4]) {
-
-                // apply UVU† where U is outer circuit and V is inner circuit
-                WithCA(TDepthOneCCNOTOuterCircuit, TDepthOneCCNOTInnerCircuit, ancillas + [target, control1, control2]);
-            }
+            // apply UVU† where U is outer circuit and V is inner circuit
+            ApplyWithCA(TDepthOneCCNOTOuterCircuit, TDepthOneCCNOTInnerCircuit, auxillaryRegister + [target, control1, control2]);
         }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
     }
 
 
@@ -243,24 +186,17 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - Used as a part of @"Microsoft.Quantum.Samples.UnitTesting.TDepthOneCCNOT"
     /// - For the circuit diagram see Figure 1 on
     ///   [ Page 3 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation TDepthOneCCNOTOuterCircuit (qs : Qubit[]) : Unit {
-
-        body (...) {
-            EqualityFactI(Length(qs), 7, "7 qubits are expected");
-            H(qs[4]);
-            CNOT(qs[5], qs[1]);
-            CNOT(qs[6], qs[3]);
-            CNOT(qs[5], qs[2]);
-            CNOT(qs[4], qs[1]);
-            CNOT(qs[3], qs[0]);
-            CNOT(qs[6], qs[2]);
-            CNOT(qs[4], qs[0]);
-            CNOT(qs[1], qs[3]);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation TDepthOneCCNOTOuterCircuit (qs : Qubit[]) : Unit is Adj + Ctl {
+        EqualityFactI(Length(qs), 7, "7 qubits are expected");
+        H(qs[4]);
+        CNOT(qs[5], qs[1]);
+        CNOT(qs[6], qs[3]);
+        CNOT(qs[5], qs[2]);
+        CNOT(qs[4], qs[1]);
+        CNOT(qs[3], qs[0]);
+        CNOT(qs[6], qs[2]);
+        CNOT(qs[4], qs[0]);
+        CNOT(qs[1], qs[3]);
     }
 
 
@@ -268,17 +204,10 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - Used as a part of @"Microsoft.Quantum.Samples.UnitTesting.TDepthOneCCNOT"
     /// - For the circuit diagram see Figure 1 on
     ///   [ Page 3 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
-    operation TDepthOneCCNOTInnerCircuit (qs : Qubit[]) : Unit {
-
-        body (...) {
-            EqualityFactI(Length(qs), 7, "7 qubits are expected");
-            ApplyToEachCA(Adjoint T, qs[0 .. 2]);
-            ApplyToEachCA(T, qs[3 .. 6]);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation TDepthOneCCNOTInnerCircuit (qs : Qubit[]) : Unit is Adj + Ctl {
+        EqualityFactI(Length(qs), 7, "7 qubits are expected");
+        ApplyToEachCA(Adjoint T, qs[0 .. 2]);
+        ApplyToEachCA(T, qs[3 .. 6]);
     }
 
 
@@ -296,28 +225,29 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     operation CCNOT3 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
 
         body (...) {
-            using (ancillas = Qubit[1]) {
-                let ancilla = ancillas[0];
-                UpToPhaseCCNOT2(control1, control2, ancilla);
-                S(ancilla);
-                CNOT(ancilla, target);
-                H(ancillas[0]);
-                AssertProb([PauliZ], [ancilla], One, 0.5, "", 1E-10);
+            using (auxillaryQubit = Qubit()) {
+                UpToPhaseCCNOT2(control1, control2, auxillaryQubit);
+                S(auxillaryQubit);
+                CNOT(auxillaryQubit, target);
+                H(auxillaryQubit);
+                AssertProb([PauliZ], [auxillaryQubit], One, 0.5, "", 1E-10);
 
-                if (M(ancilla) == One) {
+                if (M(auxillaryQubit) == One) {
                     Controlled Z([control2], control1);
-                    X(ancilla);
+                    X(auxillaryQubit);
                 }
             }
         }
-
-        adjoint self;
 
         // fall back to a standard multiply controlled X Implementation
         controlled (controls, ...) {
             Controlled X(controls + [control1, control2], target);
         }
 
+        // NB: We cannot use "is Adj" or "adjoint auto" here, due to the use of
+        //     Microsoft.Quantum.Intrinsic.M, which does is not Adj. Instead, we
+        //     explicitly use the "self" generator.
+        adjoint self;
         controlled adjoint self;
     }
 
@@ -331,30 +261,23 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// #Recall that ExpFrac used in the circuit below is an exponent of the
     ///  respective multi-qubit Pauli gate times numerator Pi() i /2^{n-1}
     ///  It is a primitive gate implemented by Quantum.Intrinsics
-    operation CCZ1 (qubit1 : Qubit, qubit2 : Qubit, qubit3 : Qubit) : Unit {
+    operation CCZ1 (qubit1 : Qubit, qubit2 : Qubit, qubit3 : Qubit) : Unit is Adj + Ctl {
+        let register = [qubit1, qubit2, qubit3];
 
-        body (...) {
-            let register = [qubit1, qubit2, qubit3];
-
-            // note that CCZ = exp( iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| )
-            // next use |1⟩⟨1| = (I-Z)/2 and write
-            // iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| =
-            //          = iπ/2³(I⊗I⊗I - Z⊗I⊗I - I⊗Z⊗I - I⊗I⊗Z + Z⊗Z⊗I + Z⊗I⊗Z + I⊗Z⊗Z - Z⊗Z⊗Z)
-            // using above we express CCZ as:
-            // exp( iπ/2³I⊗I⊗I )
-            ExpFrac([PauliI, PauliI, PauliI], 1, 3, register);
-            ExpFrac([PauliZ, PauliI, PauliI], -1, 3, register);
-            ExpFrac([PauliI, PauliZ, PauliI], -1, 3, register);
-            ExpFrac([PauliI, PauliI, PauliZ], -1, 3, register);
-            ExpFrac([PauliZ, PauliZ, PauliI], 1, 3, register);
-            ExpFrac([PauliZ, PauliI, PauliZ], 1, 3, register);
-            ExpFrac([PauliI, PauliZ, PauliZ], 1, 3, register);
-            ExpFrac([PauliZ, PauliZ, PauliZ], -1, 3, register);
-        }
-
-        adjoint self;
-        controlled distribute;
-        controlled adjoint self;
+        // note that CCZ = exp( iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| )
+        // next use |1⟩⟨1| = (I-Z)/2 and write
+        // iπ|1⟩⟨1|⊗|1⟩⟨1|⊗|1⟩⟨1| =
+        //          = iπ/2³(I⊗I⊗I - Z⊗I⊗I - I⊗Z⊗I - I⊗I⊗Z + Z⊗Z⊗I + Z⊗I⊗Z + I⊗Z⊗Z - Z⊗Z⊗Z)
+        // using above we express CCZ as:
+        // exp( iπ/2³I⊗I⊗I )
+        ExpFrac([PauliI, PauliI, PauliI], 1, 3, register);
+        ExpFrac([PauliZ, PauliI, PauliI], -1, 3, register);
+        ExpFrac([PauliI, PauliZ, PauliI], -1, 3, register);
+        ExpFrac([PauliI, PauliI, PauliZ], -1, 3, register);
+        ExpFrac([PauliZ, PauliZ, PauliI], 1, 3, register);
+        ExpFrac([PauliZ, PauliI, PauliZ], 1, 3, register);
+        ExpFrac([PauliI, PauliZ, PauliZ], 1, 3, register);
+        ExpFrac([PauliZ, PauliZ, PauliZ], -1, 3, register);
     }
 
 
@@ -363,17 +286,10 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// tensor products of Z operators
     /// # Remarks
     /// Uses 7 T gates, 10 CNOTs and two Hadamard gates and has T depth 5
-    operation CCNOT4 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit {
-
-        body (...) {
-            H(target);
-            CCZ1(control1, control2, target);
-            H(target);
-        }
-
-        adjoint self;
-        controlled distribute;
-        controlled adjoint self;
+    operation CCNOT4 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        H(target);
+        CCZ1(control1, control2, target);
+        H(target);
     }
 
 }

--- a/Samples/src/UnitTesting/CCNOTCircuitsTests.qs
+++ b/Samples/src/UnitTesting/CCNOTCircuitsTests.qs
@@ -4,61 +4,59 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Diagnostics;
-    
-    
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Unit test for circuits implementing Controlled SWAP gate, also known as Fredkin gate
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     /// # Summary
     /// This operation tests correctness of the implementation of Doubly Controlled X gates
     /// also known as Toffoli gates.
     operation CCNOTCircuitsTest () : Unit {
-        
+
         //  List of pairs of operations (expected,actual) to be tested up to a phase
         let upToPhaseTestList = [(UpToPhaseCCNOT1, CCNOT), (UpToPhaseCCNOT2, CCNOT), (UpToPhaseCCNOT3, CCNOT)];
-        
-        for (i in 0 .. Length(upToPhaseTestList) - 1) {
-            let (actual, expected) = upToPhaseTestList[i];
-            
+
+        for ((actual, expected) in upToPhaseTestList) {
+
             // This ensures that we have a list of tested circuits in the output
             // If the test fails the circuit that is wrong will be the last one in the list
             Message($"Testing {actual} against {expected} up to phases.");
-            
+
             // this checks that gates in the list act the same on all the
             // computational basis states ( up to a global phase )
             AssertOperationsEqualInPlaceCompBasis(3, ApplyToFirstThreeQubits(actual, _), ApplyToFirstThreeQubitsA(expected, _));
-            
+
             // We used partial application and ApplyToFirstThreeQubits to convert operation with
             // signature (Qubit,Qubit,Qubit) => () to operation with signature Qubit[] => ()
-            
+
             // The operation below is used for metrics collection, for more detail see
             // CircuitMetrics.cs
             CollectMetrics(actual);
         }
-        
+
         // Now proceed to test the equality of operations
         let equalTestList = [(UpToPhaseCCNOT2, UpToPhaseCCNOT3), (CCNOT1, CCNOT), (CCNOT2, CCNOT), (CCNOT3, CCNOT), (CCNOT4, CCNOT), (TDepthOneCCNOT, CCNOT)];
-        
-        for (i in 0 .. Length(equalTestList) - 1) {
-            let (actual, expected) = equalTestList[i];
-            
+
+        for ((actual, expected) in equalTestList) {
+
             // This ensures that we have a list of tested circuits in the output
             // If the test fails the circuit that is wrong will be the last one in the list
             Message($"Testing if {actual} is equal to {expected}.");
-            
+
             // this checks that gates are equal
             AssertOperationsEqualReferenced(3, ApplyToFirstThreeQubits(actual, _), ApplyToFirstThreeQubitsA(expected, _));
-            
+
             // We used partial application and ApplyToFirstThreeQubits to convert operation with
             // signature (Qubit,Qubit,Qubit) => () to operation with signature Qubit[] => ()
-            
+
             // The operation below is used for metrics collection,
             // for more detail see CircuitMetrics.cs
             CollectMetrics(actual);
         }
     }
-    
+
 }
 
 

--- a/Samples/src/UnitTesting/ControlledSWAP.qs
+++ b/Samples/src/UnitTesting/ControlledSWAP.qs
@@ -1,63 +1,49 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Samples.UnitTesting {
-    
+
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
-    
-    
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Circuits for Controlled SWAP gate
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Introduction
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     // This file contains different implementations of  Controlled SWAP gate, also known
     // as Fredkin gate.
     // (Controlled SWAP)([control],target1,target2)
     // On computational basis states Controlled SWAP
     // acts as |0⟩⊗|t₁⟩⊗|t₂⟩ ↦ |0⟩⊗|t₁⟩⊗|t₂⟩, |1⟩⊗|t₁⟩⊗|t₂⟩ ↦ |1⟩⊗|t₂⟩⊗|t₁⟩
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     /// # Summary
     /// Implementation of ControlledSWAP using standard Microsoft.Quantum.Intrinsic.SWAP
-    operation ControlledSWAP0 (control : Qubit, target1 : Qubit, target2 : Qubit) : Unit {
-        
-        body (...) {
-            Controlled SWAP([control], (target1, target2));
-        }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation ControlledSWAP0 (control : Qubit, target1 : Qubit, target2 : Qubit) : Unit is Adj + Ctl {
+        Controlled SWAP([control], (target1, target2));
     }
-    
-    
+
+
     /// # Summary
     /// Implementation of the Controlled SWAP gate in terms of CCNOT gate
     /// # Remarks
     /// Number of gates used for this implementation is 2 CNOTs + number of gates used for the
     /// implementation of CCNOTOp
-    operation ControlledSWAPUsingCCNOT (CCNOTOp : ((Qubit, Qubit, Qubit) => Unit is Adj + Ctl), control : Qubit, target1 : Qubit, target2 : Qubit) : Unit {
-        
-        body (...) {
-            // Note that SWAP(a,b) = CNOT(b,a) CNOT(a,b) CNOT(b,a)
-            // Since CNOT(b,a) is self-adjoint: CNOT(b,a)CNOT(b,a)=I,
-            // Controlled SWAP(a,b) = CNOT(b,a) CCNOT(c,a,b) CNOT(b,a)
-            CNOT(target2, target1);
-            CCNOTOp(control, target1, target2);
-            CNOT(target2, target1);
-        }
-        
-        adjoint self;
-        controlled distribute;
-        controlled adjoint self;
+    operation ControlledSWAPUsingCCNOT (CCNOTOp : ((Qubit, Qubit, Qubit) => Unit is Adj + Ctl), control : Qubit, target1 : Qubit, target2 : Qubit) : Unit is Adj + Ctl {
+        // Note that SWAP(a,b) = CNOT(b,a) CNOT(a,b) CNOT(b,a)
+        // Since CNOT(b,a) is self-adjoint: CNOT(b,a)CNOT(b,a)=I,
+        // Controlled SWAP(a,b) = CNOT(b,a) CCNOT(c,a,b) CNOT(b,a)
+        CNOT(target2, target1);
+        CCNOTOp(control, target1, target2);
+        CNOT(target2, target1);
     }
-    
-    
+
+
     /// # Summary
     /// Implementation of the 3 qubit Fredkin gate over the Clifford+T gate set,
     /// according to Amy et al
@@ -69,51 +55,44 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # See Also
     /// - For the circuit diagram see Figure 7 (e) on
     ///   [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
-    operation ControlledSWAP1 (control : Qubit, target1 : Qubit, target2 : Qubit) : Unit {
-        
-        body (...) {
-            CNOT(target1, target2);
-            
-            // layer 0
-            H(target1);
-            CNOT(control, target2);
-            
-            // layer 1
-            T(target1);
-            Adjoint T(target2);
-            T(control);
-            
-            // layer 2
-            CNOT(target1, target2);
-            
-            // layer 3
-            CNOT(control, target1);
-            T(target2);
-            
-            // layer 4
-            CNOT(control, target2);
-            Adjoint T(target1);
-            
-            // layer 5
-            Adjoint T(target2);
-            CNOT(control, target1);
-            
-            // layer 6
-            CNOT(target1, target2);
-            
-            // layer 7
-            T(target2);
-            H(target1);
-            
-            // layer 8
-            CNOT(target1, target2);
-        }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation ControlledSWAP1 (control : Qubit, target1 : Qubit, target2 : Qubit) : Unit is Adj + Ctl {
+        CNOT(target1, target2);
+
+        // layer 0
+        H(target1);
+        CNOT(control, target2);
+
+        // layer 1
+        T(target1);
+        Adjoint T(target2);
+        T(control);
+
+        // layer 2
+        CNOT(target1, target2);
+
+        // layer 3
+        CNOT(control, target1);
+        T(target2);
+
+        // layer 4
+        CNOT(control, target2);
+        Adjoint T(target1);
+
+        // layer 5
+        Adjoint T(target2);
+        CNOT(control, target1);
+
+        // layer 6
+        CNOT(target1, target2);
+
+        // layer 7
+        T(target2);
+        H(target1);
+
+        // layer 8
+        CNOT(target1, target2);
     }
-    
+
 }
 
 

--- a/Samples/src/UnitTesting/ControlledSWAP.qs
+++ b/Samples/src/UnitTesting/ControlledSWAP.qs
@@ -34,13 +34,17 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// # Remarks
     /// Number of gates used for this implementation is 2 CNOTs + number of gates used for the
     /// implementation of CCNOTOp
-    operation ControlledSWAPUsingCCNOT (CCNOTOp : ((Qubit, Qubit, Qubit) => Unit is Adj + Ctl), control : Qubit, target1 : Qubit, target2 : Qubit) : Unit is Adj + Ctl {
-        // Note that SWAP(a,b) = CNOT(b,a) CNOT(a,b) CNOT(b,a)
-        // Since CNOT(b,a) is self-adjoint: CNOT(b,a)CNOT(b,a)=I,
-        // Controlled SWAP(a,b) = CNOT(b,a) CCNOT(c,a,b) CNOT(b,a)
-        CNOT(target2, target1);
-        CCNOTOp(control, target1, target2);
-        CNOT(target2, target1);
+    operation ControlledSWAPUsingCCNOT (CCNOTOp : ((Qubit, Qubit, Qubit) => Unit is Adj + Ctl), control : Qubit, target1 : Qubit, target2 : Qubit) : Unit is Ctl {
+        body (...) {
+            // Note that SWAP(a,b) = CNOT(b,a) CNOT(a,b) CNOT(b,a)
+            // Since CNOT(b,a) is self-adjoint: CNOT(b,a)CNOT(b,a)=I,
+            // Controlled SWAP(a,b) = CNOT(b,a) CCNOT(c,a,b) CNOT(b,a)
+            CNOT(target2, target1);
+            CCNOTOp(control, target1, target2);
+            CNOT(target2, target1);
+        }
+
+        adjoint self;
     }
 
 

--- a/Samples/src/UnitTesting/MultiTargetCNOT.qs
+++ b/Samples/src/UnitTesting/MultiTargetCNOT.qs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Samples.UnitTesting {
-
+    open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Arrays;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -19,17 +20,9 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
 
     /// # Summary
     /// A simple implementation of target Controlled Not gate using CNOT gates
-    operation MultiTargetNot (controls : Qubit[], target : Qubit[]) : Unit {
-
-        body (...) {
-            Fact(Length(controls) == 1, "control register must have length 1");
-
-            for (i in 0 .. Length(target) - 1) {
-                CNOT(controls[0], target[i]);
-            }
-        }
-
-        adjoint invert;
+    operation MultiTargetNot (controls : Qubit[], target : Qubit[]) : Unit is Adj {
+        EqualityFactI(Length(controls), 1, "control register must have length 1");
+        ApplyToEachA(CNOT(Head(controls), _), target);
     }
 
 
@@ -37,21 +30,18 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// Multi target multi controlled Not implementation using
     /// ApplyMultiControlledCA
     /// # See Also
-    /// - @"Microsoft.Quantum.Canon.ApplyMultiControlledCA"
-    operation MultiTargetMultiNot (controls : Qubit[], targets : Qubit[]) : Unit {
+    /// - Microsoft.Quantum.Canon.ApplyMultiControlledCA
+    operation MultiTargetMultiNot (controls : Qubit[], targets : Qubit[]) : Unit is Adj {
 
         body (...) {
             let singlyControlledOp = ApplyToPartitionA(MultiTargetNot, 1, _);
             ApplyMultiControlledCA(singlyControlledOp, CCNOTop(CCNOT), controls, targets);
         }
 
-        adjoint invert;
-
         controlled (extraControls, ...) {
             MultiTargetMultiNot(extraControls + controls, targets);
         }
 
-        controlled adjoint invert;
     }
 
 }

--- a/Samples/src/UnitTesting/MultiTargetCNOTTests.qs
+++ b/Samples/src/UnitTesting/MultiTargetCNOTTests.qs
@@ -1,28 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Samples.UnitTesting {
-    
+
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Diagnostics;
-    
-    
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Unit test for circuits implementing Multi Target Multiply Controlled Not gates
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     /// # Summary
     /// Tests correctness of MultiTargetMultiNot implementations
     operation MultiTargetMultiControlledNotTest () : Unit {
-        
+
         //  list of the operations to test in format (actual,expected)
         let testList = [(MultiTargetMultiNot, Controlled (ApplyToEachCA(X, _)))];
-        
-        for (i in 0 .. Length(testList) - 1) {
-            let (actual, expected) = testList[i];
-            
+
+        for ((actual, expected) in testList) {
             for (totalNumberOfQubits in 1 .. 8) {
-                
+
                 // We use AssertOperationsEqualReferenced as it requires only
                 // one call to the operation being tested
                 // when the number of controls is one
@@ -36,7 +34,7 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
             }
         }
     }
-    
+
 }
 
 

--- a/Samples/src/UnitTesting/RepeatUntilSuccessCircuits.qs
+++ b/Samples/src/UnitTesting/RepeatUntilSuccessCircuits.qs
@@ -4,26 +4,26 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
-    
-    
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Circuits for exp(±i⋅ArcTan(2)⋅Z) implemented using Repeat-Until-Success (RUS) protocols
     // in term of Clifford and T gates
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Introduction
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     // In general, any Repeat-Until-Success (RUS) protocol uses a circuit with measurements
     // to implement a unitary operation on a target qubit(s). Upon success, indicated by
     // certain measurement outcomes, a circuit used in the protocol implements desired unitary.
     // Upon failure, e.g. the other measurement outcomes, the protocol implements a unitary
     // that is easy to undo ( for example, Identity operation ). The circuit is repeated
     // over an over again until the desired unitary is implemented.
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     /// # Summary
     /// Example of a Repeat-Until-Success circuit implementing exp(i⋅ArcTan(2)⋅Z)
     /// by Nielsen & Chuang. Gate exp(i⋅ArcTan(2)⋅Z) is also know as V gate.
@@ -37,38 +37,36 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - For the circuit diagram see Figure 1 (a) on Page 5
     ///   of the [arXiv:1311.1074v2](https://arxiv.org/pdf/1311.1074.pdf#page=5)
     operation ExpIZArcTan2NC (target : Qubit) : Unit {
-        
+
         body (...) {
-            using (ancillas = Qubit[2]) {
-                
+            using ((aux0, aux1) = (Qubit(), Qubit())) {
+
                 // Set both ancilla to |+⟩ state
-                ApplyToEach(H, ancillas);
-                
+                ApplyToEach(H, [aux0, aux1]);
+
                 repeat {
-                    let (ancilla0, ancilla1) = (ancillas[0], ancillas[1]);
-                    
                     // This is just a log message, so we can see how many times we tried before
                     // succeeding.
                     Message("Trying ...");
-                    
+
                     // we expect to start with both ancillas being in |+⟩ state
-                    AssertProb([PauliX], [ancilla0], Zero, 1.0, "", 1E-10);
-                    AssertProb([PauliX], [ancilla1], Zero, 1.0, "", 1E-10);
-                    
+                    AssertProb([PauliX], [aux0], Zero, 1.0, "", 1E-10);
+                    AssertProb([PauliX], [aux1], Zero, 1.0, "", 1E-10);
+
                     // use CCNOT with 4 T gates
-                    CCNOT3(ancilla0, ancilla1, target);
+                    CCNOT3(aux0, aux1, target);
                     S(target);
-                    
+
                     // use CCNOT with 4 T gates
-                    CCNOT3(ancilla0, ancilla1, target);
+                    CCNOT3(aux0, aux1, target);
                     Z(target);
-                    
+
                     // Before the measurements probability of measuring |+⟩ state on both
                     // ancillas is 3/4
-                    AssertProb([PauliX], [ancilla0], Zero, 0.75, "Error: the probability to measure |+⟩ in the first ancilla must be 3/4", 1E-10);
-                    AssertProb([PauliX], [ancilla1], Zero, 0.75, "Error: the probability to measure |+⟩ in the second ancilla must be 3/4", 1E-10);
-                    let outcome0 = Measure([PauliX], [ancilla0]);
-                    
+                    AssertProb([PauliX], [aux0], Zero, 0.75, "Error: the probability to measure |+⟩ in the first ancilla must be 3/4", 1E-10);
+                    AssertProb([PauliX], [aux1], Zero, 0.75, "Error: the probability to measure |+⟩ in the second ancilla must be 3/4", 1E-10);
+                    let outcome0 = Measure([PauliX], [aux0]);
+
                     // After the first auxillary qubit has been measured the probability is conditional
                     // upon measurement outcome.
                     // If we measured Zero on the first auxillary qubit, the probability of
@@ -77,36 +75,36 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
                     // measuring |+⟩ on the second ancilla is 1/2
                     let prob = outcome0 == One ? 0.5 | 5.0 / 6.0;
 
-                    AssertProb([PauliX], [ancilla1], Zero, prob, $"Error:the probability to measure |+⟩ in the first ancilla must be {prob}", 1E-10);
-                    let outcome1 = Measure([PauliX], [ancilla1]);
+                    AssertProb([PauliX], [aux1], Zero, prob, $"Error:the probability to measure |+⟩ in the first ancilla must be {prob}", 1E-10);
+                    let outcome1 = Measure([PauliX], [aux1]);
                 }
                 until (outcome0 == Zero and outcome1 == Zero)
                 fixup {
-                    
+
                     // Upon failure the identity gate has been applied to the target qubit
                     // Now let us record the failure to log.
                     let msg1 = "We failed. Outcomes of measuring first and second ancilla ";
                     let msg2 = $"were {(outcome0, outcome1)}. Applying fix-up and trying again";
                     Message(msg1 + msg2);
-                    
+
                     // Make sure that both ancilla are back to |+⟩ state
                     if (outcome0 == One) {
-                        Z(ancilla0);
+                        Z(aux0);
                     }
-                    
+
                     if (outcome1 == One) {
-                        Z(ancilla1);
+                        Z(aux1);
                     }
                 }
-                
+
                 // If both outcomes are Zero we successfully applied exp(i⋅ArcTan(2)⋅Z)
                 Message("Success!");
-                
+
                 // Return ancillas back to |0⟩ state
-                ApplyToEach(H, ancillas);
+                ApplyToEach(H, [aux0, aux1]);
             }
         }
-        
+
         adjoint (...) {
             // We can use the following equation to implement the Adjoint:
             // X exp(i⋅ArcTan(2)⋅Z) X = exp(i⋅ArcTan(2)⋅XZX) = exp(- i⋅ArcTan(2)⋅Z)
@@ -115,8 +113,8 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
             X(target);
         }
     }
-    
-    
+
+
     /// # Summary
     /// Example of a Repeat-Until-Success circuit implementing exp(i⋅ArcTan(2)⋅Z)
     /// by Paetznick & Svore. Gate exp(i⋅ArcTan(2)⋅Z) is also know as V gate.
@@ -128,66 +126,64 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - For the circuit diagram see Figure 1 (c) on Page
     ///   of the [arXiv:1311.1074v2](https://arxiv.org/pdf/1311.1074.pdf#page=5)
     operation ExpIZArcTan2PS (target : Qubit) : Unit {
-        
+
         body (...) {
-            using (ancillas = Qubit[1]) {
-                let ancilla = ancillas[0];
-                
+            using (auxillaryQubit = Qubit()) {
                 // Set ancilla to |+⟩ state
-                H(ancilla);
-                
+                H(auxillaryQubit);
+
                 // Note that because T and Z on the target commutes through the control,
                 // we can just count the number of T's we need to apply over the course of
                 // the protocol and apply one or zero of T's in the end.
                 mutable TGatesToApplyInTheEnd = 0;
-                
+
                 repeat {
-                    
+
                     // This is just a log message, so we can see how many times we tried before
                     // succeeding.
                     Message("Trying ...");
-                    
-                    // we expect to start with ancilla being in |+⟩ state
-                    AssertProb([PauliX], [ancilla], Zero, 1.0, "Ancilla must be in |+⟩ state", 1E-10);
-                    RepeatUntilSuccessStatePreparation(ancilla);
-                    CNOT(target, ancilla);
-                    T(ancilla);
-                    
+
+                    // we expect to start with auxillaryQubit being in |+⟩ state
+                    AssertProb([PauliX], [auxillaryQubit], Zero, 1.0, "auxillaryQubit must be in |+⟩ state", 1E-10);
+                    RepeatUntilSuccessStatePreparation(auxillaryQubit);
+                    CNOT(target, auxillaryQubit);
+                    T(auxillaryQubit);
+
                     // This is instead of Z(target), T(target)
-                    set TGatesToApplyInTheEnd = TGatesToApplyInTheEnd + 5;
-                    
-                    // The probability to measure |+⟩ on ancilla is 5/6
-                    AssertProb([PauliX], [ancilla], Zero, 5.0 / 6.0, "The probability to measure |+⟩ on ancilla must be 5/6", 1E-10);
-                    let outcome = Measure([PauliX], [ancilla]);
+                    set TGatesToApplyInTheEnd += 5;
+
+                    // The probability to measure |+⟩ on auxillaryQubit is 5/6
+                    AssertProb([PauliX], [auxillaryQubit], Zero, 5.0 / 6.0, "The probability to measure |+⟩ on auxillaryQubit must be 5/6", 1E-10);
+                    let outcome = Measure([PauliX], [auxillaryQubit]);
                 }
                 until (outcome == Zero)
                 fixup {
-                    
+
                     // Upon failure the identity gate has been applied to the target qubit
                     // Now let us record the failure to log.
                     Message("We failed. Applying fix-up");
-                    
+
                     // This is instead of Z(target)
-                    set TGatesToApplyInTheEnd = TGatesToApplyInTheEnd + 4;
-                    
-                    // Make sure that ancilla is back to |+⟩ state
-                    Z(ancilla);
+                    set TGatesToApplyInTheEnd += 4;
+
+                    // Make sure that auxillaryQubit is back to |+⟩ state
+                    Z(auxillaryQubit);
                 }
-                
+
                 // If outcome is Zero we successfully applied exp(i⋅ArcTan(2)⋅Z)
                 Message("Success!");
-                
+
                 // Now apply the required T,S and Z gates.
                 // If TGatesToApplyInTheEnd is odd one more T gates is applied, and if
                 // TGatesToApplyInTheEnd is even there are no T gates to apply
                 // In other words apply exp( i⋅π⋅k/2² |1⟩⟨1| ), where k = TGatesToApplyInTheEnd
                 R1Frac(TGatesToApplyInTheEnd, 2, target);
-                
-                // Now return ancilla to |0⟩ state
-                H(ancilla);
+
+                // Now return the auxillary qubit to the |0⟩ state
+                H(auxillaryQubit);
             }
         }
-        
+
         adjoint (...) {
             // We can use the following equation to implement the Adjoint:
             // X exp(i⋅ArcTan(2)⋅Z) X = exp(i⋅ArcTan(2)⋅XZX) = exp(- i⋅ArcTan(2)⋅Z)
@@ -196,50 +192,49 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
             X(target);
         }
     }
-    
-    
+
+
     /// # Summary
     /// Prepares state (√2/√3,1/√3) starting from a |+⟩ state
     /// using Repeat-Until-Success protocol.
     /// # Sea also
     /// - Used in @"Microsoft.Quantum.Samples.UnitTesting.ExpIZArcTan2PS"
     operation RepeatUntilSuccessStatePreparation (target : Qubit) : Unit {
-        
-        using (qubits = Qubit[1]) {
-            let ancilla = qubits[0];
-            H(ancilla);
-            
+
+        using (auxillaryQubit = Qubit()) {
+            H(auxillaryQubit);
+
             repeat {
-                
-                // we expect target and ancilla qubit to be in |+⟩ state
+
+                // we expect the target and auxillary qubits to each be in the |+⟩ state.
                 AssertProb([PauliX], [target], Zero, 1.0, "target qubit should be in |+⟩ state", 1E-10);
-                AssertProb([PauliX], [ancilla], Zero, 1.0, "ancilla qubit should be in |+⟩ state", 1E-10);
-                Adjoint T(ancilla);
-                CNOT(target, ancilla);
-                T(ancilla);
-                
-                // Probability of measuring |+⟩ state on ancilla is 3/4
-                AssertProb([PauliX], [ancilla], Zero, 3.0 / 4.0, "Error: the probability to measure |+⟩ in the first ancilla must be 3/4", 1E-10);
-                
+                AssertProb([PauliX], [auxillaryQubit], Zero, 1.0, "auxillaryQubit qubit should be in |+⟩ state", 1E-10);
+                Adjoint T(auxillaryQubit);
+                CNOT(target, auxillaryQubit);
+                T(auxillaryQubit);
+
+                // Probability of measuring |+⟩ state on auxillaryQubit is 3/4
+                AssertProb([PauliX], [auxillaryQubit], Zero, 3.0 / 4.0, "Error: the probability to measure |+⟩ in the first auxillaryQubit must be 3/4", 1E-10);
+
                 // if measurement outcome zero we prepared required state
-                let outcome = Measure([PauliX], [ancilla]);
+                let outcome = Measure([PauliX], [auxillaryQubit]);
             }
             until (outcome == Zero)
             fixup {
-                
-                // Bring ancilla and target back to |+⟩ state
+
+                // Bring auxillaryQubit and target back to |+⟩ state
                 if (outcome == One) {
-                    Z(ancilla);
+                    Z(auxillaryQubit);
                     X(target);
                     H(target);
                 }
             }
-            
-            // Return ancilla back to Zero state
-            H(ancilla);
+
+            // Return auxillaryQubit back to Zero state
+            H(auxillaryQubit);
         }
     }
-    
+
 }
 
 

--- a/Samples/src/UnitTesting/Teleportation.qs
+++ b/Samples/src/UnitTesting/Teleportation.qs
@@ -4,12 +4,12 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
-    
-    
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Circuit for teleportation with detailed annotation of measurement probabilities
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     /// # Summary
     /// Teleportation transfers 1 qubit by encoding it into a 2-bit message,
     /// using an entangled pair of qubits.
@@ -38,40 +38,39 @@ namespace Microsoft.Quantum.Samples.UnitTesting {
     /// - [ *Michael A. Nielsen , Isaac L. Chuang*,
     ///     Quantum Computation and Quantum Information ](http://doi.org/10.1017/CBO9780511976667)
     operation Teleportation (source : Qubit, target : Qubit) : Unit {
-        
+
         // Get a temporary qubit for the Bell pair.
-        using (ancillaRegister = Qubit[1]) {
-            let ancilla = ancillaRegister[0];
-            
+        using (auxillaryQubit = Qubit()) {
+
             // Create a Bell pair between the temporary qubit and the target.
             Assert([PauliZ], [target], Zero, "Error: target qubit must be initialized in zero state");
-            H(ancilla);
-            CNOT(ancilla, target);
-            Assert([PauliZ, PauliZ], [ancilla, target], Zero, "Error: EPR state must be eigenstate of ZZ");
-            Assert([PauliX, PauliX], [ancilla, target], Zero, "Error: EPR state must be eigenstate of XX");
-            
+            H(auxillaryQubit);
+            CNOT(auxillaryQubit, target);
+            Assert([PauliZ, PauliZ], [auxillaryQubit, target], Zero, "Error: EPR state must be eigenstate of ZZ");
+            Assert([PauliX, PauliX], [auxillaryQubit, target], Zero, "Error: EPR state must be eigenstate of XX");
+
             // Perform the Bell measurement and the correction necessary to
             // reconstruct the input state as the target state.
-            CNOT(source, ancilla);
+            CNOT(source, auxillaryQubit);
             H(source);
             AssertProb([PauliZ], [source], Zero, 0.5, "Error: All outcomes of the Bell measurement must be equally likely", 1E-05);
-            
+
             // Note that MResetZ makes sure that source is returned to zero state
             // so that we can deallocate it.
             if (MResetZ(source) == One) {
                 Z(target);
             }
-            
+
             // The probability of measuring 0 or 1 is independent on the previous
             // measurement outcome
-            AssertProb([PauliZ], [ancilla], Zero, 0.5, "Error: All outcomes of the Bell measurement must be equally likely", 1E-05);
-            
-            if (MResetZ(ancilla) == One) {
+            AssertProb([PauliZ], [auxillaryQubit], Zero, 0.5, "Error: All outcomes of the Bell measurement must be equally likely", 1E-05);
+
+            if (MResetZ(auxillaryQubit) == One) {
                 X(target);
             }
         }
     }
-    
+
 }
 // /////////////////////////////////////////////////////////////////////////////////////////////
 // Other teleportation circuits not illustrated here

--- a/Samples/tests/SampleTests/BitFlipTests.qs
+++ b/Samples/tests/SampleTests/BitFlipTests.qs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
+
     open Microsoft.Quantum.Samples.BitFlipCode;
 
     operation BitFlipSampleParityTest () : Unit {


### PR DESCRIPTION
This PR cleans up the unit testing sample using the new features of Q# 0.6 (e.g.: removes redundancy, makes use of improved library routines, etc.).