### PR TITLE
Fix #220 by specifying image SHA sum in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/microsoft/iqsharp/blob/master/images/iqsharp-base/Dockerfile.
 # As per Binder documentation, we choose to use an SHA sum here instead of a
 # tag.
-FROM mcr.microsoft.com/quantum/iqsharp-base:f8a1d03beccd419ed4155c60a355948ec7c7887566a63a36e9fbdace77918b36
+FROM mcr.microsoft.com/quantum/iqsharp-base@f8a1d03beccd419ed4155c60a355948ec7c7887566a63a36e9fbdace77918b36
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/microsoft/iqsharp/blob/master/images/iqsharp-base/Dockerfile.
 # As per Binder documentation, we choose to use an SHA sum here instead of a
 # tag.
-FROM mcr.microsoft.com/quantum/iqsharp-base@f8a1d03beccd419ed4155c60a355948ec7c7887566a63a36e9fbdace77918b36
+FROM mcr.microsoft.com/quantum/iqsharp-base@sha256:f8a1d03beccd419ed4155c60a355948ec7c7887566a63a36e9fbdace77918b36
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Start from the IQ# base image. The definition for this image can be found at
 # https://github.com/microsoft/iqsharp/blob/master/images/iqsharp-base/Dockerfile.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.8.1907.1701
+# As per Binder documentation, we choose to use an SHA sum here instead of a
+# tag.
+FROM mcr.microsoft.com/quantum/iqsharp-base:f8a1d03beccd419ed4155c60a355948ec7c7887566a63a36e9fbdace77918b36
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE


### PR DESCRIPTION
After fixing the `iqsharp-base` image to resolve #220 (see microsoft/iqsharp#27), Binder kept a copy of the old image, such that #220 persisted. This PR forces Binder to update to the newly-deployed image by specifying the SHA256 digest of the image instead of its tag. See https://mybinder.org/v2/gh/Microsoft/Quantum/cgranade/docker-sha for an example of Binder running against this PR.