### PR TITLE
Parameterize chemistry cmdline samples using CommandLineUtils.

### DIFF
--- a/Chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
+++ b/Chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />

--- a/Chemistry/GetGateCount/3-GetGateCount.csproj
+++ b/Chemistry/GetGateCount/3-GetGateCount.csproj
@@ -12,6 +12,7 @@
     <None Remove="TrotterGateCountEstimates.PrimitiveOperationsCounter.csv" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
@@ -19,7 +20,6 @@
     <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.8.1907.1701" />
     <PackageReference Include="Microsoft.Quantum.Standard" Version="0.8.1907.1701" />
     <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.8.1907.1701" />
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
 
 

--- a/Chemistry/GetGateCount/Program.cs
+++ b/Chemistry/GetGateCount/Program.cs
@@ -18,9 +18,9 @@ using System.Collections.Generic;
 // in a robust way that makes it easy to turn on and off different messages.
 using Microsoft.Extensions.Logging;
 
-// We use the Mono.Options and System.Management.Automation
-// libraries to make it easy to use this sample from the command line.
-using Mono.Options;
+// We use the McMaster.Extensions.CommandLineUtils
+// library to make it easy to use this sample from the command line.
+using McMaster.Extensions.CommandLineUtils;
 
 // Finally, we include the gate counting logic itself from GetGateCount.cs.
 using static Microsoft.Quantum.Chemistry.Samples.GetGateCount;
@@ -30,83 +30,58 @@ namespace Microsoft.Quantum.Chemistry.Samples
 {
     class Program
     {
-        static void Main(string[] args)
+        public static int Main(string[] args) =>
+            CommandLineApplication.Execute<Program>(args);
+        
+
+        [Option("-p|--path", Description = "Path to the integral data file to use.")]
+        public string Path { get; } = System.IO.Path.Combine(
+            "..", "IntegralData", "Liquid", "h2s_sto6g_22.dat"
+        );
+
+        [Option("-f|--format", Description="Format to use when loading integral data.")]
+        public IntegralDataFormat Format = IntegralDataFormat.Liquid;
+
+        [Option("--skip-trotter-suzuki", Description="If set, skips estimating for the Trotter–Suzuki simulation step.")]
+        public bool SkipTrotterSuzuki { get; } = false;
+        public bool RunTrotterSuzuki => !SkipTrotterSuzuki;
+
+        [Option("--skip-qubitization", Description="If set, skips estimating for the qubitized simulation step.")]
+        public bool SkipQubitization { get; } = false;
+        public bool RunQubitization => !SkipQubitization;
+
+        [Option("--skip-opt-qubitization", Description="If set, skips estimating for the optimized qubitized simulation step.")]
+        public bool SkipOptimizedQubitization { get; } = false;
+        public bool RunOptimizedQubitization => !SkipOptimizedQubitization;
+
+        [Option("-l|--log", Description="Controls where log messages will be written to.")]
+        public string LogPath { get; } = null;
+
+        [Option("-o|--output", "Specifies the folder into which gate count estimates should be written as CSVs.")]
+        public string OutputPath { get; } = null;
+        
+
+        void OnExecute()
         {
-
-            string filename = @"..\IntegralData\Liquid\h2s_sto6g_22.dat";
-            var format = IntegralDataFormat.Liquid;
-
-            bool runTrotterStep = true;
-            bool runMinQubitQubitizationStep = true;
-            bool runMinTCountQubitizationStep = true;
-            bool showHelp = false;
-            string outputFolder = null;
-
-            string logPath = null;
-
-            // These are arguments that can be set from command line.
-            var options = new OptionSet {
-                { "h|?|help", "Shows this help message.", h => showHelp = true },
-                { "p|path=", "Path to the integral data file to use.", f => filename = f },
-                { "f|format=",
-                    "Format to use when loading integral data.",
-                    (string f) => format = (IntegralDataFormat) Enum.Parse(typeof(IntegralDataFormat), f)
-                },
-                { "t|run-trotter=",
-                    "Controls whether the Trotter simulation step will be estimated.",
-                    (bool t) => runTrotterStep = t
-                },
-                { "q|run-qubitization=",
-                    "Controls whether the qubitization simulation step that minimizes qubit count will be estimated.",
-                    (bool q) => runMinQubitQubitizationStep = q
-                },
-                { "o|run-optimized-qubitization=",
-                    "Controls whether the qubitization simulation step that minimizes T count will be estimated.",
-                    (bool o) => runMinTCountQubitizationStep = o
-                },
-                { "l|log=",
-                    "Controls where log messages will be written to.",
-                    (string l) => logPath = l
-                },
-                { "output=",
-                    "Specifies the folder into which gate count estimates should be written as CSVs.",
-                    (string o) => outputFolder = o
-                }
-            };
-
-            // This parses the command line arguments, and catches undefined arguments.
-            List<string> extra;
-            try
+            if (LogPath != null)
             {
-                extra = options.Parse(args);
+                Logging.LogPath = LogPath;
             }
-            catch (OptionException)
-            {
-                ShowHelp(options);
-                System.Environment.Exit(1);
-            }
-
-            if (showHelp)
-            {
-                ShowHelp(options);
-                System.Environment.Exit(1);
-            }
-
-            Logging.LogPath = logPath;
             var logger = Logging.LoggerFactory.CreateLogger<Program>();
 
             // Here, we specify the Hamiltonian simulation configurations we wish to run.
             var configurations = Configure(
-                runTrotterStep: runTrotterStep,
-                runMinQubitQubitizationStep: runMinQubitQubitizationStep,
-                runMinTCountQubitizationStep: runMinTCountQubitizationStep);
+                runTrotterStep: RunTrotterSuzuki,
+                runMinQubitQubitizationStep: RunQubitization,
+                runMinTCountQubitizationStep: RunOptimizedQubitization
+            );
 
-            using (logger.BeginScope($"Using {filename}."))
+            using (logger.BeginScope($"Using {Path}."))
             {
                 logger.LogInformation($"Loading...");
 
                 // Read Hamiltonian terms from file and run gate counts.
-                var gateCountResults = RunGateCount(filename, format, configurations, outputFolder).Result;
+                var gateCountResults = RunGateCount(Path, Format, configurations, OutputPath).Result;
 
                 foreach(var result in gateCountResults)
                 {
@@ -120,13 +95,6 @@ namespace Microsoft.Quantum.Chemistry.Samples
             }
         }
 
-        public static void ShowHelp(OptionSet options)
-        {
-            System.Console.WriteLine("get-gatecount");
-            System.Console.WriteLine("Usage:");
-            options.WriteOptionDescriptions(Console.Out);
-            return;
-        }
     }
 
 }

--- a/Chemistry/GetGateCount/Program.cs
+++ b/Chemistry/GetGateCount/Program.cs
@@ -40,24 +40,24 @@ namespace Microsoft.Quantum.Chemistry.Samples
         );
 
         [Option("-f|--format", Description="Format to use when loading integral data.")]
-        public IntegralDataFormat Format = IntegralDataFormat.Liquid;
+        public IntegralDataFormat Format { get; } = IntegralDataFormat.Liquid;
 
         [Option("--skip-trotter-suzuki", Description="If set, skips estimating for the Trotter–Suzuki simulation step.")]
         public bool SkipTrotterSuzuki { get; } = false;
         public bool RunTrotterSuzuki => !SkipTrotterSuzuki;
 
-        [Option("--skip-qubitization", Description="If set, skips estimating for the qubitized simulation step.")]
+        [Option("--skip-qubitization", Description = "If set, skips estimating for the qubitized simulation step.")]
         public bool SkipQubitization { get; } = false;
         public bool RunQubitization => !SkipQubitization;
 
-        [Option("--skip-opt-qubitization", Description="If set, skips estimating for the optimized qubitized simulation step.")]
+        [Option("--skip-opt-qubitization", Description = "If set, skips estimating for the optimized qubitized simulation step.")]
         public bool SkipOptimizedQubitization { get; } = false;
         public bool RunOptimizedQubitization => !SkipOptimizedQubitization;
 
-        [Option("-l|--log", Description="Controls where log messages will be written to.")]
+        [Option("-l|--log", Description = "Controls where log messages will be written to.")]
         public string LogPath { get; } = null;
 
-        [Option("-o|--output", "Specifies the folder into which gate count estimates should be written as CSVs.")]
+        [Option("-o|--output", Description = "Specifies the folder into which gate count estimates should be written as CSVs.")]
         public string OutputPath { get; } = null;
         
 

--- a/Chemistry/RunSimulation/2-RunSimulation.csproj
+++ b/Chemistry/RunSimulation/2-RunSimulation.csproj
@@ -5,6 +5,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />


### PR DESCRIPTION
This PR addresses #225 by making the path a command-line argument (parsed with McMaster.Extensions.CommandLineUtils), and using `System.IO.Path.Combine` to set the initial default.