### PR TITLE
Update relative links to absolute in sample manifests.

### DIFF
--- a/samples/algorithms/chsh-game/README.md
+++ b/samples/algorithms/chsh-game/README.md
@@ -51,10 +51,10 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest
 
-- [Game.qs](./Game.qs): Q# code implementing the game.
-- [host.py](./host.py): Python host program to call into the Q# sample.
-- [Host.cs](./Host.cs): C# code to call the operations defined in Q#.
-- [CHSHGame.csproj](./CHSHGame.csproj): Main C# project for the sample.
+- [Game.qs](https://github.com/microsoft/quantum/tree/master/samples/algorithms/chsh-game/Game.qs): Q# code implementing the game.
+- [host.py](https://github.com/microsoft/quantum/tree/master/samples/algorithms/chsh-game/host.py): Python host program to call into the Q# sample.
+- [Host.cs](https://github.com/microsoft/quantum/tree/master/samples/algorithms/chsh-game/Host.cs): C# code to call the operations defined in Q#.
+- [CHSHGame.csproj](https://github.com/microsoft/quantum/tree/master/samples/algorithms/chsh-game/CHSHGame.csproj): Main C# project for the sample.
 
 ## Further resources
 

--- a/samples/algorithms/simple-grover/README.md
+++ b/samples/algorithms/simple-grover/README.md
@@ -50,7 +50,7 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [SimpleGrover.qs](./SimpleGrover.qs): Q# code implementing quantum operations for this sample.
-- [Host.cs](./Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
-- [SimpleGroverSample.csproj](./SimpleGroverSample.csproj): Main C# project for the sample.
+- [SimpleGrover.qs](https://github.com/microsoft/quantum/tree/master/samples/algorithms/simple-grover/SimpleGrover.qs): Q# code implementing quantum operations for this sample.
+- [Host.cs](https://github.com/microsoft/quantum/tree/master/samples/algorithms/simple-grover/Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
+- [SimpleGroverSample.csproj](https://github.com/microsoft/quantum/tree/master/samples/algorithms/simple-grover/SimpleGroverSample.csproj): Main C# project for the sample.
 

--- a/samples/characterization/phase-estimation/README.md
+++ b/samples/characterization/phase-estimation/README.md
@@ -1,4 +1,4 @@
----
+﻿---
 page_type: sample
 languages:
 - qsharp
@@ -47,7 +47,7 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [PhaseEstimationSample.csproj](./PhaseEstimationSample.csproj): Main C# project for the example.
-- [Host.cs](./Host.cs): C# code to call the operations defined in Q#.
-- [host.py](./host.py): a sample Python program to call the Q# phase estimation operation.
-- [BayesianPhaseEstimation.qs](./BayesianPhaseEstimation.qs): The Q# implementation of iterative phase estimation and Bayesian inference.
+- [PhaseEstimationSample.csproj](https://github.com/microsoft/quantum/tree/master/samples/characterization/phase-estimation/PhaseEstimationSample.csproj): Main C# project for the example.
+- [Host.cs](https://github.com/microsoft/quantum/tree/master/samples/characterization/phase-estimation/Host.cs): C# code to call the operations defined in Q#.
+- [host.py](https://github.com/microsoft/quantum/tree/master/samples/characterization/phase-estimation/host.py): a sample Python program to call the Q# phase estimation operation.
+- [BayesianPhaseEstimation.qs](https://github.com/microsoft/quantum/tree/master/samples/characterization/phase-estimation/BayesianPhaseEstimation.qs): The Q# implementation of iterative phase estimation and Bayesian inference.

--- a/samples/getting-started/intro-to-iqsharp/README.md
+++ b/samples/getting-started/intro-to-iqsharp/README.md
@@ -28,6 +28,6 @@ jupyter notebook Notebook.ipynb
 
 ## Manifest
 
-- [Notebook.ipynb](./Notebook.ipynb): a Jupyter Notebook demonstrating how to simulate Q# operations and functions.
-- [Operations.qs](./Operations.qs): Q# code called from the Jupyter Notebook for this sample.
+- [Notebook.ipynb](https://github.com/microsoft/quantum/tree/master/samples/getting-started/intro-to-iqsharp/Notebook.ipynb): a Jupyter Notebook demonstrating how to simulate Q# operations and functions.
+- [Operations.qs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/intro-to-iqsharp/Operations.qs): Q# code called from the Jupyter Notebook for this sample.
 

--- a/samples/getting-started/simple-algorithms/README.md
+++ b/samples/getting-started/simple-algorithms/README.md
@@ -36,8 +36,8 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [SimpleAlgorithms.qs](./SimpleAlgorithms.qs): Q# code implementing quantum operations for this sample.
-- [Host.cs](./Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
-- [SimpleAlgorithms.csproj](./SimpleAlgorithms.csproj): Main C# project for the sample.
+- [SimpleAlgorithms.qs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/simple-algorithms/SimpleAlgorithms.qs): Q# code implementing quantum operations for this sample.
+- [Host.cs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/simple-algorithms/Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
+- [SimpleAlgorithms.csproj](https://github.com/microsoft/quantum/tree/master/samples/getting-started/simple-algorithms/SimpleAlgorithms.csproj): Main C# project for the sample.
 
 

--- a/samples/getting-started/teleportation/README.md
+++ b/samples/getting-started/teleportation/README.md
@@ -59,9 +59,9 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [TeleportationSample.qs](./TeleportationSample.qs): Q# code defining how to teleport qubit states.
-- [Utils.qs](./Utils.qs): Q# code with some utility operations used to prepare and read |+> and |-> states.
-- [Host.cs](./Program.cs): C# code to call the operations defined in Q#.
-- [TeleportationSample.csproj](./TeleportationSample.csproj): Main C# project for the example.
-- [host.py](./host.py): a sample Python program to call the Q# teleport operation.
-- [Notebook.ipynb](./Notebook.ipynb): a Jupyter notebook that shows how to implement the Q# teleport operation.
+- [TeleportationSample.qs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/TeleportationSample.qs): Q# code defining how to teleport qubit states.
+- [Utils.qs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/Utils.qs): Q# code with some utility operations used to prepare and read |+> and |-> states.
+- [Host.cs](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/Program.cs): C# code to call the operations defined in Q#.
+- [TeleportationSample.csproj](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/TeleportationSample.csproj): Main C# project for the example.
+- [host.py](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/host.py): a sample Python program to call the Q# teleport operation.
+- [Notebook.ipynb](https://github.com/microsoft/quantum/tree/master/samples/getting-started/teleportation/Notebook.ipynb): a Jupyter notebook that shows how to implement the Q# teleport operation.


### PR DESCRIPTION
This PR modifies sample manifests to be absolute, so that links render correctly at https://docs.microsoft.com/samples as well as in the repo itself. Thanks to @crazy4pi314 and @lobrien for reporting the issue!