### PR TITLE
dotnetcli identifier and fix broken link

### DIFF
--- a/samples/algorithms/chsh-game/README.md
+++ b/samples/algorithms/chsh-game/README.md
@@ -40,7 +40,7 @@ python host.py
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -51,12 +51,11 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest
 
-- [Game.qs](./Game.qs): Q# code implementing the game.
-- [host.py](./host.py): Python host program to call into the Q# sample.
-- [Host.cs](./Host.cs): C# code to call the operations defined in Q#.
-- [CHSHGame.csproj](./CHSHGame.csproj): Main C# project for the sample.
+- [Game.qs](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/chsh-game/Game.qs): Q# code implementing the game.
+- [host.py](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/chsh-game/host.py): Python host program to call into the Q# sample.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/chsh-game/Host.cs): C# code to call the operations defined in Q#.
+- [CHSHGame.csproj](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/chsh-game/CHSHGame.csproj): Main C# project for the sample.
 
 ## Further resources
 
 - [Measurement concepts](https://docs.microsoft.com/quantum/concepts/pauli-measurements)
-

--- a/samples/algorithms/simple-grover/README.md
+++ b/samples/algorithms/simple-grover/README.md
@@ -13,11 +13,11 @@ description: "This sample implements Grover's search algorithm, an example of a 
 
 This sample implements Grover's search algorithm, an example of a quantum development technique known as _amplitude amplification_.
 Oracles implementing the database are explicitly constructed together with all steps of the algorithm.
-See the [DatabaseSearch](../database-search/README.md) sample for and extended version and the [Grover Search Kata](https://github.com/microsoft/QuantumKatas/tree/master/GroversAlgorithm) to learn more about Grover's algorithm and how to implement it in Q#.
+See the [DatabaseSearch](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/database-search/README.md) sample for and extended version and the [Grover Search Kata](https://github.com/microsoft/QuantumKatas/tree/master/GroversAlgorithm) to learn more about Grover's algorithm and how to implement it in Q#.
 
 This sample uses the example of an operation that marks inputs of the form "010101…", then uses Grover's algorithm to find these inputs given only the ability to call that operation.
 In this case, the sample uses a hard-coded operation, but operations and functions in the [Microsoft.Quantum.AmplitudeAmplification namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.amplitudeamplification) can be used to efficiently and easily construct different inputs to Grover's algorithm, and to quickly build up useful variations of amplitude amplification for different applications.
-For examples of how to solve more general problems using amplitude amplification, check out the more in-depth [database search sample](../database-search).
+For examples of how to solve more general problems using amplitude amplification, check out the more in-depth [database search sample](https://github.com/microsoft/Quantum/tree/master/samples/algorithms/database-search).
 
 ## Prerequisites ##
 
@@ -39,7 +39,7 @@ python host.py
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -50,7 +50,7 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [SimpleGrover.qs](./SimpleGrover.qs): Q# code implementing quantum operations for this sample.
-- [Host.cs](./Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
-- [SimpleGroverSample.csproj](./SimpleGroverSample.csproj): Main C# project for the sample.
+- [SimpleGrover.qs](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/simple-grover/SimpleGrover.qs): Q# code implementing quantum operations for this sample.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/simple-grover/Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
+- [SimpleGroverSample.csproj](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/simple-grover/SimpleGroverSample.csproj): Main C# project for the sample.
 

--- a/samples/characterization/phase-estimation/README.md
+++ b/samples/characterization/phase-estimation/README.md
@@ -35,7 +35,7 @@ python host.py
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -47,7 +47,7 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [PhaseEstimationSample.csproj](./PhaseEstimationSample.csproj): Main C# project for the example.
-- [Host.cs](./Host.cs): C# code to call the operations defined in Q#.
-- [host.py](./host.py): a sample Python program to call the Q# phase estimation operation.
-- [BayesianPhaseEstimation.qs](./BayesianPhaseEstimation.qs): The Q# implementation of iterative phase estimation and Bayesian inference.
+- [PhaseEstimationSample.csproj](https://github.com/microsoft/Quantum/tree/master/samples/characterization/phase-estimation/PhaseEstimationSample.csproj): Main C# project for the example.
+- [Host.cs](https://github.com/microsoft/Quantum/tree/master/samples/characterization/phase-estimation/Host.cs): C# code to call the operations defined in Q#.
+- [host.py](https://github.com/microsoft/Quantum/tree/master/samples/characterization/phase-estimation/host.py): a sample Python program to call the Q# phase estimation operation.
+- [BayesianPhaseEstimation.qs](https://github.com/microsoft/Quantum/tree/master/samples/characterization/phase-estimation/BayesianPhaseEstimation.qs): The Q# implementation of iterative phase estimation and Bayesian inference.

--- a/samples/getting-started/intro-to-iqsharp/README.md
+++ b/samples/getting-started/intro-to-iqsharp/README.md
@@ -20,7 +20,7 @@ This sample demonstrates:
 
 ## Running the Sample
 
-From the command line, start Jupyter Notebook and open the [Notebook.ipynb](./Notebook.ipynb) file.
+From the command line, start Jupyter Notebook and open the [Notebook.ipynb](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/intro-to-iqsharp/Notebook.ipynb) file.
 
 ```
 jupyter notebook Notebook.ipynb
@@ -28,6 +28,5 @@ jupyter notebook Notebook.ipynb
 
 ## Manifest
 
-- [Notebook.ipynb](./Notebook.ipynb): a Jupyter Notebook demonstrating how to simulate Q# operations and functions.
-- [Operations.qs](./Operations.qs): Q# code called from the Jupyter Notebook for this sample.
-
+- [Notebook.ipynb](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/intro-to-iqsharp/Notebook.ipynb): a Jupyter Notebook demonstrating how to simulate Q# operations and functions.
+- [Operations.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/intro-to-iqsharp/Operations.qs): Q# code called from the Jupyter Notebook for this sample.

--- a/samples/getting-started/measurement/README.md
+++ b/samples/getting-started/measurement/README.md
@@ -40,7 +40,7 @@ python host.py
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -51,13 +51,12 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest
 
-- [Measurement.qs](./Measurement.qs): Q# code preparing and measuring a few qubits.
-- [host.py](./host.py): Python host program to call into the Q# sample.
-- [Host.cs](./Host.cs): C# code to call the operations defined in Q#.
-- [Measurement.csproj](./Measurement.csproj): Main C# project for the sample.
+- [Measurement.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/measurement/Measurement.qs): Q# code preparing and measuring a few qubits.
+- [host.py](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/measurement/host.py): Python host program to call into the Q# sample.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/measurement/Host.cs): C# code to call the operations defined in Q#.
+- [Measurement.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/measurement/Measurement.csproj): Main C# project for the sample.
 
 ## Further resources
 
 - [Measurement concepts](https://docs.microsoft.com/quantum/concepts/pauli-measurements)
 - [Logging and assertion techniques](https://docs.microsoft.com/quantum/techniques/testing-and-debugging#logging-and-assertions)
-

--- a/samples/getting-started/simple-algorithms/README.md
+++ b/samples/getting-started/simple-algorithms/README.md
@@ -25,7 +25,7 @@ This sample can be run in a number of different ways, depending on your preferre
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -36,8 +36,8 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [SimpleAlgorithms.qs](./SimpleAlgorithms.qs): Q# code implementing quantum operations for this sample.
-- [Host.cs](./Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
-- [SimpleAlgorithms.csproj](./SimpleAlgorithms.csproj): Main C# project for the sample.
+- [SimpleAlgorithms.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/SimpleAlgorithms.qs): Q# code implementing quantum operations for this sample.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
+- [SimpleAlgorithms.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/Host.cs): Main C# project for the sample.
 
 

--- a/samples/getting-started/simple-algorithms/README.md
+++ b/samples/getting-started/simple-algorithms/README.md
@@ -38,6 +38,6 @@ Press Start in Visual Studio to run the sample.
 
 - [SimpleAlgorithms.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/SimpleAlgorithms.qs): Q# code implementing quantum operations for this sample.
 - [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/Host.cs): C# code to interact with and print out results of the Q# operations for this sample.
-- [SimpleAlgorithms.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/Host.cs): Main C# project for the sample.
+- [SimpleAlgorithms.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/simple-algorithms/SimpleAlgorithms.csproj): Main C# project for the sample.
 
 

--- a/samples/getting-started/teleportation/README.md
+++ b/samples/getting-started/teleportation/README.md
@@ -30,7 +30,7 @@ This sample can be run in a number of different ways, depending on your preferre
 
 ### Jupyter Notebook ###
 
-From the command line, start Jupyter Notebook and open the [Notebook.ipynb](./Notebook.ipynb) file.
+From the command line, start Jupyter Notebook and open the [Notebook.ipynb](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Notebook.ipynb) file.
 
 ```
 jupyter notebook Notebook.ipynb
@@ -48,7 +48,7 @@ python host.py
 
 At a terminal, run the following command:
 
-```bash
+```dotnetcli
 dotnet run
 ```
 
@@ -59,9 +59,9 @@ Press Start in Visual Studio to run the sample.
 
 ## Manifest ##
 
-- [TeleportationSample.qs](./TeleportationSample.qs): Q# code defining how to teleport qubit states.
-- [Utils.qs](./Utils.qs): Q# code with some utility operations used to prepare and read |+> and |-> states.
-- [Host.cs](./Program.cs): C# code to call the operations defined in Q#.
-- [TeleportationSample.csproj](./TeleportationSample.csproj): Main C# project for the example.
-- [host.py](./host.py): a sample Python program to call the Q# teleport operation.
-- [Notebook.ipynb](./Notebook.ipynb): a Jupyter notebook that shows how to implement the Q# teleport operation.
+- [TeleportationSample.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/TeleportationSample.qs): Q# code defining how to teleport qubit states.
+- [Utils.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Utils.qs): Q# code with some utility operations used to prepare and read |+> and |-> states.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Program.cs): C# code to call the operations defined in Q#.
+- [TeleportationSample.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/TeleportationSample.csproj): Main C# project for the example.
+- [host.py](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/host.py): a sample Python program to call the Q# teleport operation.
+- [Notebook.ipynb](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Notebook.ipynb): a Jupyter notebook that shows how to implement the Q# teleport operation.

--- a/samples/getting-started/teleportation/README.md
+++ b/samples/getting-started/teleportation/README.md
@@ -61,7 +61,7 @@ Press Start in Visual Studio to run the sample.
 
 - [TeleportationSample.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/TeleportationSample.qs): Q# code defining how to teleport qubit states.
 - [Utils.qs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Utils.qs): Q# code with some utility operations used to prepare and read |+> and |-> states.
-- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Program.cs): C# code to call the operations defined in Q#.
+- [Host.cs](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Host.cs): C# code to call the operations defined in Q#.
 - [TeleportationSample.csproj](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/TeleportationSample.csproj): Main C# project for the example.
 - [host.py](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/host.py): a sample Python program to call the Q# teleport operation.
 - [Notebook.ipynb](https://github.com/microsoft/Quantum/blob/master/samples/getting-started/teleportation/Notebook.ipynb): a Jupyter notebook that shows how to implement the Q# teleport operation.


### PR DESCRIPTION
Links under Manifest aren't working correctly in [samples explorer](https://docs.microsoft.com/en-us/samples/microsoft/quantum/simple-quantum-algorithms/). This change should fix that.