### PR TITLE
Minor bug fixes for the state visualizer sample

### DIFF
--- a/samples/runtime/state-visualizer/StateVisualizer.cs
+++ b/samples/runtime/state-visualizer/StateVisualizer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.Samples.StateVisualizer
 
         private void OnOperationEndHandler(ICallable operation, IApplyData result)
         {
-            BroadcastAsync("OperationEnded", result?.Value.ToString(), stateDumper.DumpAndGetAmplitudes()).Wait();
+            BroadcastAsync("OperationEnded", result?.Value?.ToString(), stateDumper.DumpAndGetAmplitudes()).Wait();
             WaitForAdvance().Wait();
         }
 

--- a/samples/runtime/state-visualizer/StateVisualizer.cs
+++ b/samples/runtime/state-visualizer/StateVisualizer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.Samples.StateVisualizer
 
         private void OnOperationEndHandler(ICallable operation, IApplyData result)
         {
-            BroadcastAsync("OperationEnded", result?.Value, stateDumper.DumpAndGetAmplitudes()).Wait();
+            BroadcastAsync("OperationEnded", result?.Value.ToString(), stateDumper.DumpAndGetAmplitudes()).Wait();
             WaitForAdvance().Wait();
         }
 

--- a/samples/runtime/state-visualizer/websrc/app.ts
+++ b/samples/runtime/state-visualizer/websrc/app.ts
@@ -207,9 +207,11 @@ function onOperationStarted(operationName: string, input: number[], state: State
     const operation = document.createElement("li");
     operation.className = "next";
     operation.innerHTML =
-        `<span class="operation-name">${operationName}</span>` +
-        `(<span class="operation-args">${input.join(", ")}</span>)` +
-        `<ol class="operation-children"></ol>`;
+        '<span class="operation-name"></span>' +
+        '(<span class="operation-args"></span>)' +
+        '<ol class="operation-children"></ol>';
+    operation.querySelector(".operation-name").textContent = operationName;
+    operation.querySelector(".operation-args").textContent = input.join(", ");
     appendOperation(operation);
     operations.push(operation);
     updateChart(state);
@@ -239,7 +241,8 @@ function onLog(message: string, state: State): void {
     clearIcon();
     const operation = document.createElement("li");
     operation.className = "next";
-    operation.textContent = message;
+    operation.innerHTML = '<span class="operation-name"></span>';
+    operation.querySelector(".operation-name").textContent = message;
     appendOperation(operation);
     updateChart(state);
 

--- a/samples/runtime/state-visualizer/websrc/app.ts
+++ b/samples/runtime/state-visualizer/websrc/app.ts
@@ -217,16 +217,15 @@ function onOperationStarted(operationName: string, input: number[], state: State
     pushHistory(null, operation, state);
 }
 
-function onOperationEnded(output: any, state: State): void {
-    console.log("Operation end:", output);
+function onOperationEnded(returnValue: string, state: State): void {
+    console.log("Operation end:", returnValue);
 
     clearIcon();
     const operation = operations.pop();
     operation.className = "last";
-
-    // Show only return values that aren't unit.
-    if (!(output instanceof Object) || Object.keys(output).length > 0) {
-        operation.appendChild(document.createTextNode(` = ${output}`));
+    if (returnValue !== "()") {
+        // Show only return values that aren't unit.
+        operation.appendChild(document.createTextNode(` = ${returnValue}`));
     }
 
     updateChart(state);

--- a/samples/runtime/state-visualizer/websrc/index.html
+++ b/samples/runtime/state-visualizer/websrc/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>Q# State Visualizer.</title>
+        <title>Q# State Visualizer</title>
     </head>
     <body>
         <div class="toolbar">


### PR DESCRIPTION
Just a few bug fixes for things I found while writing my Q# Advent Calendar post about the state visualizer:

1. There was something wrong with the serialization of operation return values (unit appeared in JavaScript as `{qubits: null}`, and `One` and `Zero` were both `{}` for some reason). I convert them to strings before sending them to the web client now.
2. Fixed a bug where log messages did not cause the timeline to scroll down when they were added (they were missing an element with the `operation-name` class).
3. Removed a period that was at the end of the page title. :)