### PR TITLE
 Delay updating binder until MCR image is available.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         $Now = [DateTime]::Now;
         $ImageTag = "${{ github.sha }}"
         $RepoName = "public/quantum/samples"
-        
+
         $LocalTag = "${RepoName}:${ImageTag}"
         $RemoteRepo = "${{ secrets.ACR_REGISTRY }}/${RepoName}"
 
@@ -46,9 +46,16 @@ jobs:
 
         $ImageAvailable = $false;
         $ImageTag = "${{ github.sha }}";
+        $CheckInterval = 30; # [seconds]
         while (-not $ImageAvailable) {
-          $ImageAvailable = $ImageTag -in (Get-Tags);
-          Start-Sleep -Seconds (60 * 5);
+          if ($ImageTag -in (Get-Tags)) {
+            Write-Host "##[info] Image $ImageTag now available on mcr.microsoft.com, proceeding."
+            $ImageAvailable = $true;
+          } else {
+            Write-Host "##[info] Image $ImageTag not yet available on mcr.microsoft.com, waiting $CheckInterval seconds.";
+          }
+
+          Start-Sleep -Seconds $CheckInterval;
         }
       shell: pwsh
     - name: Update Binder configuration
@@ -58,7 +65,7 @@ jobs:
         $ThisCommit = "${{ github.sha }}"
         git checkout ⭐binder
         git reset --hard $ThisCommit
-        
+
         $Dockerfile = Get-Content ./Dockerfile;
         $Dockerfile `
           | ForEach-Object {
@@ -73,7 +80,7 @@ jobs:
         git add Dockerfile
         git commit -m "Updated Binder to use $ThisCommit."
       shell: pwsh
-    
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - cgranade/delay-update-binder # FIXME: This is for testing only, and must be removed.
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - cgranade/delay-update-binder # FIXME: This is for testing only, and must be removed.
 
 jobs:
   build:
@@ -32,6 +33,23 @@ jobs:
         docker push "${RemoteRepo}:${ImageTag}"
         docker tag $LocalTag "${RemoteRepo}:latest"
         docker push "${RemoteRepo}:latest"
+      shell: pwsh
+    - name: Wait for image to publish
+      run: |
+        function Get-Tags() {
+          Invoke-WebRequest https://mcr.microsoft.com/v2/quantum/samples/tags/list `
+            | Select-Object -ExpandProperty Content `
+            | ConvertFrom-Json `
+            | Select-Object -ExpandProperty tags `
+            | Write-Output;
+        }
+
+        $ImageAvailable = $false;
+        $ImageTag = "${{ github.sha }}";
+        while (-not $ImageAvailable) {
+          $ImageAvailable = $ImageTag -in (Get-Tags);
+          Start-Sleep -Seconds (60 * 5);
+        }
       shell: pwsh
     - name: Update Binder configuration
       run: |


### PR DESCRIPTION
This PR delays updating the special `★binder` branch until the Docker image has successfully been replicated to mcr.microsoft.com, polling the MCR catalog until the relevant tag appears. By default, the poll is set to a 30 second interval, relying on GitHub Actions' timeout to terminate the workflow if there is a problem.