### PR TITLE
Wait for manifest rather than CDNed tag.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,19 +35,22 @@ jobs:
       shell: pwsh
     - name: Wait for image to publish
       run: |
-        function Get-Tags() {
-          Invoke-WebRequest https://mcr.microsoft.com/v2/quantum/samples/tags/list `
-            | Select-Object -ExpandProperty Content `
-            | ConvertFrom-Json `
-            | Select-Object -ExpandProperty tags `
-            | Write-Output;
+        function Test-Manifest() {
+          try {
+            $manifest = Invoke-RestMethod `
+              "https://mcr.microsoft.com/v2/quantum/samples/manifests/${{ github.sha }}" `
+              -ErrorAction Continue;
+            Write-Verbose $manifest;
+            return $true;
+          } catch {
+            return $false;
+          }
         }
 
         $ImageAvailable = $false;
-        $ImageTag = "${{ github.sha }}";
         $CheckInterval = 30; # [seconds]
         while (-not $ImageAvailable) {
-          if ($ImageTag -in (Get-Tags)) {
+          if (Test-Manifest) {
             Write-Host "##[info] Image $ImageTag now available on mcr.microsoft.com, proceeding."
             $ImageAvailable = $true;
           } else {


### PR DESCRIPTION
This fixes the issue with GitHub Actions not publishing updates to the `★binder` branch by waiting for the right manifest to appear on mcr.microsoft.com rather than looking at the list of tags. This is needed as mcr.microsoft.com now caches the list of tags behind a CDN, such that it is updated well after the image is available for pulling into Binder.