### PR TITLE
Add Python hosts to QML samples

### DIFF
--- a/samples/machine-learning/half-moons/Host.cs
+++ b/samples/machine-learning/half-moons/Host.cs
@@ -77,11 +77,7 @@ namespace Microsoft.Quantum.Samples
         {
             using var dataReader = File.OpenRead(dataPath);
             return await JsonSerializer.DeserializeAsync<DataSet>(
-                dataReader,
-                new JsonSerializerOptions
-                {
-                    ReadCommentHandling = JsonCommentHandling.Skip
-                }
+                dataReader
             );
         }
 

--- a/samples/machine-learning/half-moons/data.json
+++ b/samples/machine-learning/half-moons/data.json
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 {
     "TrainingData": {
         "Features": [

--- a/samples/machine-learning/half-moons/host.py
+++ b/samples/machine-learning/half-moons/host.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import json
+
+import qsharp
+qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.10.2002.1104-beta")
+qsharp.reload()
+
+from Microsoft.Quantum.Samples import TrainHalfMoonModel, ValidateHalfMoonModel
+
+if __name__ == "__main__":
+    with open('data.json') as f:
+        data = json.load(f)
+    parameter_starting_points = [
+        [0.060057, 3.00522,  2.03083,  0.63527,  1.03771, 1.27881, 4.10186,  5.34396],
+        [0.586514, 3.371623, 0.860791, 2.92517,  1.14616, 2.99776, 2.26505,  5.62137],
+        [1.69704,  1.13912,  2.3595,   4.037552, 1.63698, 1.27549, 0.328671, 0.302282],
+        [5.21662,  6.04363,  0.224184, 1.53913,  1.64524, 4.79508, 1.49742,  1.545]
+     ]
+
+    (parameters, bias) = TrainHalfMoonModel.simulate(
+        trainingVectors=data['TrainingData']['Features'],
+        trainingLabels=data['TrainingData']['Labels'],
+        initialParameters=parameter_starting_points
+    )
+
+    miss_rate = ValidateHalfMoonModel.simulate(
+        validationVectors=data['ValidationData']['Features'],
+        validationLabels=data['ValidationData']['Labels'],
+        parameters=parameters, bias=bias
+    )
+
+    print(f"Miss rate: {miss_rate:0.2%}")

--- a/samples/machine-learning/wine/host.py
+++ b/samples/machine-learning/wine/host.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import qsharp
+qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.10.2002.1104-beta")
+qsharp.reload()
+
+from Microsoft.Quantum.Samples import TrainWineModel, ValidateWineModel
+
+if __name__ == "__main__":
+    (parameters, bias) = TrainWineModel.simulate()
+
+    miss_rate = ValidateWineModel.simulate(
+        parameters=parameters, bias=bias
+    )
+
+    print(f"Miss rate: {miss_rate:0.2%}")


### PR DESCRIPTION
This PR adds Python hosts for the QML samples. Note that these hosts rely on the beta packages hosted on the prerelease feed, and thus will require NuGet.Config changes until the final QML release.