### PR TITLE
Add link to iterative phase estimation docs to sample readme

### DIFF
--- a/samples/characterization/phase-estimation/README.md
+++ b/samples/characterization/phase-estimation/README.md
@@ -12,7 +12,7 @@ urlFragment: iterative-phase-estimation
 
 # Iterative Phase Estimation
 
-This sample demonstrates iterative phase estimation using Bayesian inference to provide a simple method to perform the classical statistical analysis.
+This sample demonstrates iterative phase estimation using Bayesian inference to provide a simple method to perform the classical statistical analysis. You can read more about iterative phase estimation in [our documentation on quantum characterization and statistics](https://docs.microsoft.com/quantum/libraries/standard/characterization#iterative-phase-estimation).
 
 ## Prerequisites ##
 


### PR DESCRIPTION
For a bit of context, I was searching for "iterative phase estimation" and this sample was both the first result (docs view) and the third one (GitHub view), but it doesn't point to the relevant page in our docs. It seems like including such link would be a good idea.