### PR TITLE
Add name meta data to test inclusion of jupyter notebooks in code

### DIFF
--- a/samples/arithmetic/AdderExample.ipynb
+++ b/samples/arithmetic/AdderExample.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "name": "add-operation"
+    "name": "add-operation",
     "scrolled": true
    },
    "outputs": [

--- a/samples/arithmetic/AdderExample.ipynb
+++ b/samples/arithmetic/AdderExample.ipynb
@@ -22,6 +22,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "name": "add-operation"
     "scrolled": true
    },
    "outputs": [


### PR DESCRIPTION
Inclusion of Jupyter notebook code snippets into docs require name meta data in the cell that is being referenced. Testing that here.