### PR TITLE
Update Binder link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Microsoft Quantum Development Kit Samples #
 
- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Microsoft/Quantum/master)
+ [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Microsoft/Quantum/⭐binder)
 
 These samples demonstrate the use of the Quantum Development Kit for a variety of different quantum computing tasks.
 


### PR DESCRIPTION
This PR just updates the MyBinder link in the main README.md file to point to the ⭐binder branch. I've verified that navigating to [this new link](https://mybinder.org/v2/gh/Microsoft/Quantum/⭐binder) pulls the correct image and results in good performance when opening a notebook. The 'Kernel Ready' message appears in about 5 seconds, and then initial execution of a Q# code cell takes only a few seconds.