### PR TITLE
Improve clean.ps1 to be a bit more robust.

### DIFF
--- a/Build/clean.ps1
+++ b/Build/clean.ps1
@@ -6,8 +6,12 @@ $ErrorActionPreference = 'Stop'
 & "$PSScriptRoot/set-env.ps1"
 $all_ok = $True
 
-Get-ChildItem -recurse *.csproj, *.fsproj `
+Get-ChildItem -Recurse -Path ".." -Include *.csproj, *.fsproj `
     | ForEach-Object { $_.Directory } `
     | Sort-Object `
     | Get-Unique `
-    | ForEach-Object { dotnet clean $_ };
+    | ForEach-Object {
+        Write-Host "##[info] Cleaning $_.";
+        dotnet clean $_ `
+            --configuration $Env:BUILD_CONFIGURATION;
+    };

--- a/Build/set-env.ps1
+++ b/Build/set-env.ps1
@@ -16,5 +16,3 @@ If ($Env:TOOLS_DIR -eq $null) { $Env:TOOLS_DIR =  [IO.Path]::GetFullPath((Join-P
 
 If ($Env:NUGET_OUTDIR -eq $null) { $Env:NUGET_OUTDIR =  (Join-Path $Env:DROPS_DIR "nugets") }
 If (-not (Test-Path -Path $Env:NUGET_OUTDIR)) { [IO.Directory]::CreateDirectory($Env:NUGET_OUTDIR) }
-
-


### PR DESCRIPTION
This PR uses more explicit paths and build configurations when cleaning to make sure that clean steps match build steps.