### PR TITLE
Switch to latest images for build agents

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -14,14 +14,17 @@ variables:
 
 jobs:
 - job: Windows
-  pool: 'Hosted VS2017'
+  pool:
+    vmImage: 'windows-latest'
   steps:
   - template: Build/steps.yml
 - job: macOS
-  pool: 'Hosted macOS'
+  pool:
+    vmImage: 'macOS-latest'
   steps:
   - template: Build/steps.yml
 - job: Linux
-  pool: 'Hosted Ubuntu 1604'
+  pool:
+    vmImage: 'ubuntu-latest'
   steps:
   - template: Build/steps.yml

--- a/build.yml
+++ b/build.yml
@@ -15,7 +15,7 @@ variables:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2019'
   steps:
   - template: Build/steps.yml
 - job: macOS


### PR DESCRIPTION
Switching QDK pipeline to use latest images for build agents. There are corresponding PRs in other repos as well.