### PR TITLE
Some fixes to samples headers and metadata

### DIFF
--- a/samples/interoperability/qrng/README.md
+++ b/samples/interoperability/qrng/README.md
@@ -9,7 +9,7 @@ products:
 description: "This sample implements a quantum random number generator using Q#, a good first example to teach how to use the language."
 ---
 
-# Creating random numbers with quantum computing
+# Creating random numbers with quantum computing (host)
 
 This sample implements a quantum random number generator, a very simple application that is useful to learn how to write a first Q# code and it's integration with the host programs in C# or Python.
 

--- a/samples/interoperability/qrng/README.md
+++ b/samples/interoperability/qrng/README.md
@@ -9,7 +9,7 @@ products:
 description: "This sample implements a quantum random number generator using Q#, a good first example to teach how to use the language."
 ---
 
-# Creating random numbers with quantum computing (host)
+# Run Q# programs from Python or .NET
 
 This sample implements a quantum random number generator, a very simple application that is useful to learn how to write a first Q# code and it's integration with the host programs in C# or Python.
 

--- a/samples/machine-learning/half-moons/README.md
+++ b/samples/machine-learning/half-moons/README.md
@@ -2,17 +2,17 @@
 page_type: sample
 languages:
 - qsharp
-# - python # TODO
+- python
 - csharp
 products:
 - qdk
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset."
 ---
 
-# Training sequential models with Q\#
+# Training sequential models with Q\# (half-moons)
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
-The model is trained on a half-moon dataset, loaded in C# using the System.Text.Json package or in Python using the `json` module, then preprocessed using Q#.
+The model is trained on a half-moons dataset, loaded in C# using the System.Text.Json package or in Python using the `json` module, then preprocessed using Q#.
 
 
 ## Prerequisites
@@ -23,14 +23,13 @@ The model is trained on a half-moon dataset, loaded in C# using the System.Text.
 
 This sample can be run in a number of different ways, depending on your preferred environment.
 
-<!-- TODO
 ### Python in Visual Studio Code or the Command Line ###
 
 At a terminal, run the following command:
 
 ```bash
 python host.py
-``` -->
+```
 
 ### C# in Visual Studio Code or the Command Line
 

--- a/samples/machine-learning/half-moons/README.md
+++ b/samples/machine-learning/half-moons/README.md
@@ -9,7 +9,7 @@ products:
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset."
 ---
 
-# Training sequential models with Q\# (half-moons)
+# Training sequential models with Q\#, using data loaded from JSON
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
 The model is trained on a half-moons dataset, loaded in C# using the System.Text.Json package or in Python using the `json` module, then preprocessed using Q#.

--- a/samples/machine-learning/parallel-half-moons/README.md
+++ b/samples/machine-learning/parallel-half-moons/README.md
@@ -8,10 +8,10 @@ products:
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset, parallelizing over target machines."
 ---
 
-# Training sequential models with Q\# (parallel half moons)
+# Training sequential models with Q\# (parallel half-moons)
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
-The model is trained on a half-moon dataset, loaded in C# using the System.Text.Json package, then preprocessed using Q#.
+The model is trained on a half-moons dataset, loaded in C# using the System.Text.Json package, then preprocessed using Q#.
 
 In this sample, the training loop is parallelized over model start points, with each model using its own instance of the full-state quantum simulator.
 Parallelizing in this way can lead to significantly improved performance, especially when using a large number of cores on a small number of qubits.

--- a/samples/machine-learning/parallel-half-moons/README.md
+++ b/samples/machine-learning/parallel-half-moons/README.md
@@ -8,7 +8,7 @@ products:
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset, parallelizing over target machines."
 ---
 
-# Training sequential models with Q\# (parallel half-moons)
+# Training sequential models with Q\#, using multiple simulators in parallel
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
 The model is trained on a half-moons dataset, loaded in C# using the System.Text.Json package, then preprocessed using Q#.

--- a/samples/machine-learning/parallel-half-moons/README.md
+++ b/samples/machine-learning/parallel-half-moons/README.md
@@ -8,7 +8,7 @@ products:
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset, parallelizing over target machines."
 ---
 
-# Training sequential models with Q\#
+# Training sequential models with Q\# (parallel half moons)
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
 The model is trained on a half-moon dataset, loaded in C# using the System.Text.Json package, then preprocessed using Q#.

--- a/samples/machine-learning/wine/README.md
+++ b/samples/machine-learning/wine/README.md
@@ -9,7 +9,7 @@ products:
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset."
 ---
 
-# Training sequential models with Q\# (wine)
+# Training sequential models with Q\#, using built-in datasets
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
 The model is trained on the [wine dataset](https://archive.ics.uci.edu/ml/datasets/wine) from the [UCI Machine Learning Repository](https://archive.ics.uci.edu/), using a classifier structure defined in Q#.

--- a/samples/machine-learning/wine/README.md
+++ b/samples/machine-learning/wine/README.md
@@ -2,14 +2,14 @@
 page_type: sample
 languages:
 - qsharp
-# - python # TODO
+- python
 - csharp
 products:
 - qdk
 description: "This sample implements using the quantum machine learning library to train a sequential model on the half-moons dataset."
 ---
 
-# Training sequential models with Q\#
+# Training sequential models with Q\# (wine)
 
 This sample uses Q# and the Microsoft.Quantum.MachineLearning library to train a simple sequential model.
 The model is trained on the [wine dataset](https://archive.ics.uci.edu/ml/datasets/wine) from the [UCI Machine Learning Repository](https://archive.ics.uci.edu/), using a classifier structure defined in Q#.
@@ -23,14 +23,13 @@ The model is trained on the [wine dataset](https://archive.ics.uci.edu/ml/datase
 
 This sample can be run in a number of different ways, depending on your preferred environment.
 
-<!-- TODO
 ### Python in Visual Studio Code or the Command Line ###
 
 At a terminal, run the following command:
 
 ```bash
 python host.py
-``` -->
+```
 
 ### C# in Visual Studio Code or the Command Line
 


### PR DESCRIPTION
I changed the H1 headers of some duplicated samples. I think it is better than adding a URL but keeping the same names since they would be difficult to discern from the samples browser.

Also uncommented some TODOs of the metadata and body. This is the first try to solve the metadata issues that are breaking the samples pipeline.