### PR TITLE
Set IQ# HostingEnvironment to "build-agent"

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -11,6 +11,7 @@ variables:
   Build.Patch: $(Build.BuildId)
   Build.Configuration: 'Release'
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
+  IQSharp.Hosting.Env: 'build-agent'
 
 jobs:
 - job: Windows

--- a/build.yml
+++ b/build.yml
@@ -11,7 +11,7 @@ variables:
   Build.Patch: $(Build.BuildId)
   Build.Configuration: 'Release'
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
-  IQSharp.Hosting.Env: 'build-agent'
+  IQSharp.Hosting.Env: 'build-agent-quantum'
 
 jobs:
 - job: Windows


### PR DESCRIPTION
This PR sets IQ# HostingEnvironment to "build-agent" in order to identify telemetry coming from CI processes.