### PR TITLE
Updated to Microsoft.Quantum.MachineLearning::0.11.2006.403

### DIFF
--- a/samples/machine-learning/half-moons/HalfMoons.csproj
+++ b/samples/machine-learning/half-moons/HalfMoons.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2004.2825" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2006.403" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/machine-learning/half-moons/host.py
+++ b/samples/machine-learning/half-moons/host.py
@@ -10,7 +10,7 @@ import matplotlib.cm as cmx
 plt.style.use('ggplot')
 
 import qsharp
-qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.11.2004.2825")
+qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.11.2006.403")
 qsharp.reload()
 
 from Microsoft.Quantum.Samples import (

--- a/samples/machine-learning/parallel-half-moons/ParallelHalfMoons.csproj
+++ b/samples/machine-learning/parallel-half-moons/ParallelHalfMoons.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2004.2825" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2006.403" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/machine-learning/wine/Wine.csproj
+++ b/samples/machine-learning/wine/Wine.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2004.2825" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.11.2006.403" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/machine-learning/wine/host.py
+++ b/samples/machine-learning/wine/host.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import qsharp
-qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.11.2004.2825")
+qsharp.packages.add("Microsoft.Quantum.MachineLearning::0.11.2006.403")
 qsharp.reload()
 
 from Microsoft.Quantum.Samples import TrainWineModel, ValidateWineModel


### PR DESCRIPTION
These examples don't seem to work for QDK latest versions. I downloaded them and they didn't work. I debugged the error and finally replaced the versions and then they started to work.