### PR TITLE
IQuantumProcessor sample for qpic output

### DIFF
--- a/samples/runtime/qpic-simulator/intrinsics/Library.qs
+++ b/samples/runtime/qpic-simulator/intrinsics/Library.qs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Samples {
     /// # Summary
-    /// A simulator specific operation to specify a picture scope
+    /// A simulator-specific operation to specify a picture scope.
     ///
     /// # Description
     /// The scope is opened with a standard call to the operation
-    /// and closed with an Ajoint call to the operation.
+    /// and closed with an `Adjoint` call to the operation.
     ///
     /// # Example
     /// Saves qpic commands into `filename.qpic`
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Samples {
     }
 
     /// # Summary
-    /// A simulator specific operation to add a qpic BARRIER command.
+    /// A simulator-specific operation to add a qpic BARRIER command.
     operation Barrier() : Unit {
     }
 }

--- a/samples/runtime/qpic-simulator/intrinsics/Library.qs
+++ b/samples/runtime/qpic-simulator/intrinsics/Library.qs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+namespace Microsoft.Quantum.Samples {
+    /// # Summary
+    /// A simulator specific operation to specify a picture scope
+    ///
+    /// # Description
+    /// The scope is opened with a standard call to the operation
+    /// and closed with an Ajoint call to the operation.
+    ///
+    /// # Example
+    /// Saves qpic commands into `filename.qpic`
+    /// ```Q#
+    /// within { SavePicture("filename.qpic"); }
+    /// apply {
+    ///   using ((a, b) = (Qubit(), Qubit())) {
+    ///     H(a);
+    ///     CNOT(a, b);
+    ///   }
+    /// }
+    /// ```
+    operation SavePicture(filename : String) : Unit is Adj {
+    }
+
+    /// # Summary
+    /// A simulator specific operation to add a qpic BARRIER command.
+    operation Barrier() : Unit {
+    }
+}

--- a/samples/runtime/qpic-simulator/intrinsics/intrinsics.csproj
+++ b/samples/runtime/qpic-simulator/intrinsics/intrinsics.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+</Project>

--- a/samples/runtime/qpic-simulator/intrinsics/intrinsics.csproj
+++ b/samples/runtime/qpic-simulator/intrinsics/intrinsics.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20070124">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 </Project>

--- a/samples/runtime/qpic-simulator/simulator/Formatter.cs
+++ b/samples/runtime/qpic-simulator/simulator/Formatter.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Quantum.Samples
     // Qubit, and Pauli can be passed as formatting arguments.
     internal sealed class QpicFormatter : IFormatProvider, ICustomFormatter
     {
-        public object GetFormat(Type formatType) => (formatType == typeof(ICustomFormatter)) ? this : null;
+        public object? GetFormat(Type? formatType) => (formatType == typeof(ICustomFormatter)) ? this : null;
 
-        public string Format(string fmt, object? arg, IFormatProvider formatProvider) =>
+        public string Format(string? fmt, object? arg, IFormatProvider? formatProvider) =>
             arg switch
             {
                 Qubit q => $"q{q.Id}",

--- a/samples/runtime/qpic-simulator/simulator/Formatter.cs
+++ b/samples/runtime/qpic-simulator/simulator/Formatter.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
+
 using System;
 using System.Globalization;
 using Microsoft.Quantum.Simulation.Core;
@@ -10,13 +13,16 @@ namespace Microsoft.Quantum.Samples
     // implementation will make heavily use of string formatting for this
     // purpose, it is convenient to use a custom formatter such that types like
     // Qubit, and Pauli can be passed as formatting arguments.
-    internal sealed class QpicFormatter : IFormatProvider, ICustomFormatter {
+    internal sealed class QpicFormatter : IFormatProvider, ICustomFormatter
+    {
         public object GetFormat(Type formatType) => (formatType == typeof(ICustomFormatter)) ? this : null;
 
-        public string Format(string fmt, object arg, IFormatProvider formatProvider) =>
-            arg switch {
+        public string Format(string fmt, object? arg, IFormatProvider formatProvider) =>
+            arg switch
+            {
                 Qubit q => $"q{q.Id}",
-                Pauli p => p switch {
+                Pauli p => p switch
+                {
                     Pauli.PauliI => "I",
                     Pauli.PauliX => "X",
                     Pauli.PauliY => "Y",
@@ -30,7 +36,7 @@ namespace Microsoft.Quantum.Samples
 
         private static readonly Lazy<QpicFormatter> instance = new Lazy<QpicFormatter>(() => new QpicFormatter());
 
-        public static QpicFormatter Instance { get => instance.Value; }
+        public static QpicFormatter Instance => instance.Value;
 
         private QpicFormatter() {}
     }

--- a/samples/runtime/qpic-simulator/simulator/Formatter.cs
+++ b/samples/runtime/qpic-simulator/simulator/Formatter.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Globalization;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Samples
+{
+    // The QPicSimulator creates text files with qpic commands. Since its
+    // implementation will make heavily use of string formatting for this
+    // purpose, it is convenient to use a custom formatter such that types like
+    // Qubit, and Pauli can be passed as formatting arguments.
+    internal sealed class QpicFormatter : IFormatProvider, ICustomFormatter {
+        public object GetFormat(Type formatType) => (formatType == typeof(ICustomFormatter)) ? this : null;
+
+        public string Format(string fmt, object arg, IFormatProvider formatProvider) =>
+            arg switch {
+                Qubit q => $"q{q.Id}",
+                Pauli p => p switch {
+                    Pauli.PauliI => "I",
+                    Pauli.PauliX => "X",
+                    Pauli.PauliY => "Y",
+                    Pauli.PauliZ => "Z",
+                    _ => ""
+                },
+                IFormattable formattable => formattable.ToString(fmt, CultureInfo.CurrentCulture),
+                null => String.Empty,
+                _ => arg.ToString()
+            };
+
+        private static readonly Lazy<QpicFormatter> instance = new Lazy<QpicFormatter>(() => new QpicFormatter());
+
+        public static QpicFormatter Instance { get => instance.Value; }
+
+        private QpicFormatter() {}
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/Processor.cs
+++ b/samples/runtime/qpic-simulator/simulator/Processor.cs
@@ -99,21 +99,6 @@ namespace Microsoft.Quantum.Samples
             AddCommand("{0} G {{$T^\\dagger$}}", qubit);
         }
 
-        public override void ExpFrac(IQArray<Pauli> paulis, long numerator, long power, IQArray<Qubit> qubits) {
-            // we are using a color coding for some angles according to the visualizations in
-            // [arXiv:1808.02892](https://arxiv.org/abs/1808.02892)
-            var style = (numerator, power) switch {
-                (1, 1) => ":fill={{rgb,255:red,217; green,217; blue,217}}",
-                (1, 2) => ":fill={{rgb,255:red,245; green,189; blue,112}}",
-                (1, 4) => ":fill={{rgb,255:red,229; green,255; blue,162}}",
-                _ => ""
-            };
-
-            var format = String.Join(" ", Enumerable.Range(0, (int)qubits.Length)
-                                                    .Zip(paulis, (index, pauli) => String.Format(QpicFormatter.Instance, "{{{0}}} P{1} {{{{{2}}}}}", index, style, pauli)));
-            AddCommand(format, qubits.ToArray<object>());
-        }
-
         public override void Reset(Qubit qubit) {
             AddCommand("{0} OUT {{0}}", qubit);
         }

--- a/samples/runtime/qpic-simulator/simulator/Processor.cs
+++ b/samples/runtime/qpic-simulator/simulator/Processor.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Quantum.Samples
         // string.
         public void AddCommand(string format, params object[] args) {
             // get all Qubit objects from args
-            var qubitIds = args.Select(obj => obj switch { Qubit q => q, _ => null })
-                               .WhereNotNull();
+            var qubitIds = args.OfType<Qubit>();
 
             foreach (var builder in Pictures.Values) {
                 builder.AppendFormat(QpicFormatter.Instance, format, args);
@@ -162,12 +161,17 @@ namespace Microsoft.Quantum.Samples
 
         // No action needs to be taken in the `RunThenClause` method.  It
         // returns true to ensure that the corresponding operations in the
-        // `then` clause are executed.
+        // `then` clause are executed.  The `statement` parameter corresponds to
+        // the return value of `StartConditionalStatement` to link conditional
+        // statements that involve the same qubit.
         public override bool RunThenClause(long statement) => true;
 
         // In the `RunElseClause` method the invert flag of the corresponding
         // dictionary entry is toggled.  The method also returns true to ensure
         // that the corresponding operations in the `else` clause are executed.
+        // The `statement` parameter corresponds to the return value of
+        // `StartConditionalStatement` to link conditional statements that
+        // involve the same qubit.
         public override bool RunElseClause(long statement) {
             var (qubit, invert) = classicallyControlledQubits[statement];
             classicallyControlledQubits[statement] = (qubit, !invert);
@@ -176,7 +180,10 @@ namespace Microsoft.Quantum.Samples
 
         // When finishing a conditional statement, the corresponding entry is
         // removed from the dictionary, and a qpic command for the visual
-        // termination of the measured qubit is added.
+        // termination of the measured qubit is added.  The `statement`
+        // parameter corresponds to the return value of
+        // `StartConditionalStatement` to link conditional statements that
+        // involve the same qubit.
         public override void EndConditionalStatement(long statement) {
             var (qubit, _) = classicallyControlledQubits[statement];
             AddCommand("{0} OUT {{}}", qubit);

--- a/samples/runtime/qpic-simulator/simulator/Processor.cs
+++ b/samples/runtime/qpic-simulator/simulator/Processor.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Samples
+{
+    internal class QpicProcessor : QuantumProcessorBase {
+        // This dictionary tracks open `SaveImage` scopes with the filename as
+        // its key and a `StringBuilder` object as value.  The `StringBuilder`
+        // object is populated with qpic commands for all open scopes.
+        public Dictionary<String, StringBuilder> Pictures { get; } = new Dictionary<String, StringBuilder>();
+
+        // This dictionary tracks measured qubits in `if` statements.  The key
+        // is the qubit id and the value is a pair consisting of the
+        // corresponding `Qubit` object and a flag that controls whether
+        // operations are classically controlled on a |0〉 value or a |1〉 value.
+        private Dictionary<long, (Qubit, bool)> classicallyControlledQubits = new Dictionary<long, (Qubit, bool)>();
+
+        // This method adds a qpic command to all open `StringBuilder` objects
+        // corresponding to all open `SavePicture` scopes.  It also extends
+        // commands with classical control directives if necessary.  Qubit
+        // objects should be passed as argument, and not as part of the format
+        // string.
+        public void AddCommand(string format, params object[] args) {
+            // get all Qubit objects from args
+            var qubitIds = args.Select(obj => obj switch { Qubit q => q, _ => null })
+                               .WhereNotNull();
+
+            foreach (var builder in Pictures.Values) {
+                builder.AppendFormat(QpicFormatter.Instance, format, args);
+                foreach (var (qubit, invert) in classicallyControlledQubits.Values) {
+                    if (!qubitIds.Contains(qubit)) {
+                        builder.AppendFormat(QpicFormatter.Instance, " {1}{0}", qubit, invert ? "-" : "");
+                    }
+                }
+                builder.AppendLine();
+            }
+        }
+
+        #region Quantum operations
+        public override void OnAllocateQubits(IQArray<Qubit> qubits) {
+            foreach (var qubit in qubits) {
+                AddCommand("{0} W", qubit);
+            }
+        }
+
+        public override void X(Qubit qubit) {
+            AddCommand("{0} X", qubit);
+        }
+
+        public override void ControlledX(IQArray<Qubit> controls, Qubit qubit) {
+            var format = String.Join(" ", Enumerable.Range(0, (int)controls.Length).Select(i => $"{{{i}}}")) + $" +{{{controls.Length}}}";
+
+            AddCommand(format, controls.Append(qubit).ToArray<object>());
+        }
+
+        public override void Y(Qubit qubit) {
+            AddCommand("{0} Y", qubit);
+        }
+
+        public override void ControlledY(IQArray<Qubit> controls, Qubit qubit) {
+            var format = "{{{0}}} Y " + String.Join(" ", Enumerable.Range(0, (int)controls.Length).Select(i => $"{{{i + 1}}}"));
+
+            AddCommand(format, controls.Append(qubit).ToArray<object>());
+        }
+
+        public override void Z(Qubit qubit) {
+            AddCommand("{0} Z", qubit);
+        }
+
+        public override void ControlledZ(IQArray<Qubit> controls, Qubit qubit) {
+            var format = "{{{0}}} Z " + String.Join(" ", Enumerable.Range(0, (int)controls.Length).Select(i => $"{{{i + 1}}}"));
+
+            AddCommand(format, controls.Prepend(qubit).ToArray<object>());
+        }
+
+        public override void H(Qubit qubit) {
+            AddCommand("{0} H", qubit);
+        }
+
+        public override void S(Qubit qubit) {
+            AddCommand("{0} G {{$S$}}", qubit);
+        }
+
+        public override void SAdjoint(Qubit qubit) {
+            AddCommand("{0} G {{$S^\\dagger$}}", qubit);
+        }
+
+        public override void T(Qubit qubit) {
+            AddCommand("{0} G {{$T$}}", qubit);
+        }
+
+        public override void TAdjoint(Qubit qubit) {
+            AddCommand("{0} G {{$T^\\dagger$}}", qubit);
+        }
+
+        public override void ExpFrac(IQArray<Pauli> paulis, long numerator, long power, IQArray<Qubit> qubits) {
+            // we are using a color coding for some angles according to the visualizations in
+            // [arXiv:1808.02892](https://arxiv.org/abs/1808.02892)
+            var style = (numerator, power) switch {
+                (1, 1) => ":fill={{rgb,255:red,217; green,217; blue,217}}",
+                (1, 2) => ":fill={{rgb,255:red,245; green,189; blue,112}}",
+                (1, 4) => ":fill={{rgb,255:red,229; green,255; blue,162}}",
+                _ => ""
+            };
+
+            var format = String.Join(" ", Enumerable.Range(0, (int)qubits.Length)
+                                                    .Zip(paulis, (index, pauli) => String.Format(QpicFormatter.Instance, "{{{0}}} P{1} {{{{{2}}}}}", index, style, pauli)));
+            AddCommand(format, qubits.ToArray<object>());
+        }
+
+        public override void Reset(Qubit qubit) {
+            AddCommand("{0} OUT {{0}}", qubit);
+        }
+        #endregion
+
+        #region Classical control
+        // This is a custom Result class which can hold the qubit that is being
+        // measured.  In this simulator we are not interested in the simulation
+        // value, but need to keep track of qubits that were being measured to
+        // support classical control.
+        class DelayedResult : Result {
+            public Qubit Qubit { get; set; }
+
+            // Since we are not interested in the outcome of a measurement, we
+            // simply return One.  This method needs to be implemented to avoid
+            // an exception from being thrown, but the value will not be used by
+            // the simulator.
+            public override ResultValue GetValue() {
+                return ResultValue.One;
+            }
+        }
+
+        // A measurement is used to keep track of the measured qubit, and adds a
+        // qpic measurement command.
+        public override Result M(Qubit qubit) {
+            AddCommand("{0} M", qubit);
+            return new DelayedResult { Qubit = qubit };
+        }
+
+        // When starting a conditional statement, the measured qubit is obtained
+        // from the measurementResult argument.  The inversion flag is
+        // initialized with respect to the result value.  If it's `Zero`,
+        // operations in the `then` clause are negatively controlled, and
+        // operations in the `else` clause are positively controlled.  If it's
+        // `One`, it's the other way around.  Both variables are inserted into
+        // the dictionary for classically controlled qubits.  The qubit's id is
+        // used as identifier to link successive methods to the same conditinal
+        // statement.
+        public override long StartConditionalStatement(Result measurementResult, Result resultValue) {
+            var qubit = ((DelayedResult)measurementResult).Qubit;
+            var invert = resultValue == Result.Zero;
+            classicallyControlledQubits.Add(qubit.Id, (qubit, invert));
+            return qubit.Id;
+        }
+
+        // No action needs to be taken in the `RunThenClause` method.  It
+        // returns true to ensure that the corresponding operations in the
+        // `then` clause are executed.
+        public override bool RunThenClause(long statement) => true;
+
+        // In the `RunElseClause` method the invert flag of the corresponding
+        // dictionary entry is toggled.  The method also returns true to ensure
+        // that the corresponding operations in the `else` clause are executed.
+        public override bool RunElseClause(long statement) {
+            var (qubit, invert) = classicallyControlledQubits[statement];
+            classicallyControlledQubits[statement] = (qubit, !invert);
+            return true;
+        }
+
+        // When finishing a conditional statement, the corresponding entry is
+        // removed from the dictionary, and a qpic command for the visual
+        // termination of the measured qubit is added.
+        public override void EndConditionalStatement(long statement) {
+            var (qubit, _) = classicallyControlledQubits[statement];
+            AddCommand("{0} OUT {{}}", qubit);
+            classicallyControlledQubits.Remove(statement);
+        }
+        #endregion
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/Processor.cs
+++ b/samples/runtime/qpic-simulator/simulator/Processor.cs
@@ -9,7 +9,8 @@ using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.Samples
 {
-    internal class QpicProcessor : QuantumProcessorBase {
+    internal class QpicProcessor : QuantumProcessorBase
+    {
         // This dictionary tracks open `SaveImage` scopes with the filename as
         // its key and a `StringBuilder` object as value.  The `StringBuilder`
         // object is populated with qpic commands for all open scopes.

--- a/samples/runtime/qpic-simulator/simulator/RewriteStep.cs
+++ b/samples/runtime/qpic-simulator/simulator/RewriteStep.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled;
+
+// This rewrite step invokes the `ReplaceClassicalControl` transformation to
+// ensure that conditional statements are put into a canonical form and can be
+// recognized in the QpicProcessor.
+namespace Microsoft.Quantum.Samples
+{
+    class QpicRewriteStep : IRewriteStep {
+        public string Name { get; } = "QpicRewriteStep";
+        public int Priority { get; } = 20;
+        public IDictionary<string, string> AssemblyConstants { get; } = new Dictionary<string, string>();
+        public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics { get; } = new List<IRewriteStep.Diagnostic>();
+        public bool ImplementsPreconditionVerification { get; } = false;
+        public bool ImplementsTransformation { get; } = true;
+        public bool ImplementsPostconditionVerification { get; } = false;
+
+        public bool PreconditionVerification(QsCompilation compilation) {
+            throw new NotImplementedException();
+        }
+        
+        public bool Transformation(QsCompilation compilation, out QsCompilation transformed) {
+            transformed = ReplaceClassicalControl.Apply(compilation);
+            return true;
+        }
+        
+        public bool PostconditionVerification(QsCompilation compilation) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/RewriteStep.cs
+++ b/samples/runtime/qpic-simulator/simulator/RewriteStep.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Quantum.QsCompiler;

--- a/samples/runtime/qpic-simulator/simulator/Simulator.Barrier.cs
+++ b/samples/runtime/qpic-simulator/simulator/Simulator.Barrier.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
+
 using System;
 using Microsoft.Quantum.Simulation.QuantumProcessor;
 using Microsoft.Quantum.Simulation.Core;

--- a/samples/runtime/qpic-simulator/simulator/Simulator.Barrier.cs
+++ b/samples/runtime/qpic-simulator/simulator/Simulator.Barrier.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Microsoft.Quantum.Simulation.QuantumProcessor;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Samples
+{
+    public partial class QpicSimulator : QuantumProcessorDispatcher {
+        // Implementation of the `Barrier` operation for the QpicSimulator
+        public class BarrierImpl : Barrier {
+            private QpicProcessor processor;
+
+            public BarrierImpl(QpicSimulator m) : base(m) {
+                processor = (QpicProcessor)m.QuantumProcessor;
+            }
+
+            // Adds a BARRIER qpic command to all open scopes.
+            public override Func<QVoid, QVoid> Body => _ => {
+                processor.AddCommand("BARRIER");
+                return QVoid.Instance;
+            };
+        }
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/Simulator.SavePicture.cs
+++ b/samples/runtime/qpic-simulator/simulator/Simulator.SavePicture.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Text;
+using Microsoft.Quantum.Simulation.QuantumProcessor;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Samples
+{
+    public partial class QpicSimulator : QuantumProcessorDispatcher {
+        // Implementation of the `SavePicture` operation for the QpicSimulator
+        public class SavePictureImpl : SavePicture {
+            private QpicProcessor processor;
+
+            public SavePictureImpl(QpicSimulator m) : base(m) {
+                processor = (QpicProcessor)m.QuantumProcessor;
+            }
+
+            // The body operation adds a new empty scope to the processor
+            // indexed by the filename.
+            public override Func<String, QVoid> Body => filename => {
+                processor.Pictures.Add(filename, new StringBuilder());
+                return QVoid.Instance;
+            };
+
+            // The adjoint operation saves the picture and removes the scope
+            // from the processor.
+            public override Func<String, QVoid> AdjointBody => filename => {
+                System.IO.File.WriteAllText(filename, processor.Pictures[filename].ToString());
+                processor.Pictures.Remove(filename);
+                return QVoid.Instance;
+            };
+        }
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/Simulator.cs
+++ b/samples/runtime/qpic-simulator/simulator/Simulator.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Quantum.Simulation.QuantumProcessor;
+
+namespace Microsoft.Quantum.Samples
+{
+    public partial class QpicSimulator : QuantumProcessorDispatcher {
+        public QpicSimulator() : base(new QpicProcessor()) {}
+    }
+}

--- a/samples/runtime/qpic-simulator/simulator/simulator.csproj
+++ b/samples/runtime/qpic-simulator/simulator/simulator.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.Net.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.403" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.403" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\intrinsics\intrinsics.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/runtime/qpic-simulator/simulator/simulator.csproj
+++ b/samples/runtime/qpic-simulator/simulator/simulator.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.Net.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20070124" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20070124" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.12.20070124" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR implements a C# library containing a custom `ICustomProcessor`-based Q# simulator to dump Q# program execution traces into qpic files. It does not support all intrinsic operations and is used as accompanying sample to the 3rd Q# blog post on custom simulators. It also contains an `intrinsics` project with custom Q# operations for the simulator.

There is a lot of code this time, so I created a feature branch. Two upcoming PRs will add (i) a Q# test project with sample code to create qpic pictures and (ii) README and meta data for the sample.
