### PR TITLE
Updating electron version for H2 simulation

### DIFF
--- a/samples/simulation/h2/gui/package-lock.json
+++ b/samples/simulation/h2/gui/package-lock.json
@@ -4,6 +4,23 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@electron/get": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.2.tgz",
+            "integrity": "sha512-vAuHUbfvBQpYTJ5wB7uVIDq5c/Ry0fiTBMs7lnEYAo/qXXppIVcWdfBr57u6eRnKdVso7KSiH6p/LbQAG6Izrg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "env-paths": "^2.2.0",
+                "fs-extra": "^8.1.0",
+                "global-agent": "^2.0.2",
+                "global-tunnel-ng": "^2.7.1",
+                "got": "^9.6.0",
+                "progress": "^2.0.3",
+                "sanitize-filename": "^1.6.2",
+                "sumchecker": "^3.0.1"
+            }
+        },
         "@types/node": {
             "version": "8.10.36",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
@@ -300,31 +317,14 @@
             }
         },
         "electron": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.11.tgz",
-            "integrity": "sha512-bFTMDQN3epfiymqTPdgffyTxuy/7A52sIkW7Hos+hY5XLPArOXLXAKx1JtB3dM7CcPfZa+5qp/J3cPCidh5WXg==",
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-7.2.4.tgz",
+            "integrity": "sha512-Z+R692uTzXgP8AHrabE+kkrMlQJ6pnAYoINenwj9QSqaD2YbO8IuXU9DMCcUY0+VpA91ee09wFZJNUKYPMnCKg==",
             "dev": true,
             "requires": {
-                "@types/node": "^8.0.24",
-                "electron-download": "^3.0.1",
+                "@electron/get": "^1.0.1",
+                "@types/node": "^12.0.12",
                 "extract-zip": "^1.0.3"
-            }
-        },
-        "electron-download": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-            "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
-            "dev": true,
-            "requires": {
-                "debug": "^2.2.0",
-                "fs-extra": "^0.30.0",
-                "home-path": "^1.0.1",
-                "minimist": "^1.2.0",
-                "nugget": "^2.0.0",
-                "path-exists": "^2.1.0",
-                "rc": "^1.1.2",
-                "semver": "^5.3.0",
-                "sumchecker": "^1.2.0"
             }
         },
         "error-ex": {


### PR DESCRIPTION
Updated electron to 7.2.4, which is the minimum suggested version.