### PR TITLE
Update MS.Extensions.Logging to .NET Core 3.1.

### DIFF
--- a/samples/chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
+++ b/samples/chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
     <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.12.20070124" />
   </ItemGroup>
 

--- a/samples/chemistry/GetGateCount/3-GetGateCount.csproj
+++ b/samples/chemistry/GetGateCount/3-GetGateCount.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.12.20070124" />
   </ItemGroup>

--- a/samples/chemistry/RunSimulation/2-RunSimulation.csproj
+++ b/samples/chemistry/RunSimulation/2-RunSimulation.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
     <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.12.20070124" />
     <PackageReference Include="Microsoft.Quantum.Research" Version="0.12.20070124" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the version of MS.Extensions.Logging used to 3.1.x, in keeping with existing dependencies on .NET Core SDK 3.1.