### PR TITLE
Remove linguist-documentation attribute from samples folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,4 @@
 ###############################################################################
 # GitHub Linguist settings for repository language stats
 ###############################################################################
-samples/* -linguist-documentation
+samples/** -linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,8 @@
 # diff behavior for some non-binary formats
 ###############################################################################
 *.md diff=text
+
+###############################################################################
+# GitHub Linguist settings for repository language stats
+###############################################################################
+samples/* -linguist-documentation


### PR DESCRIPTION
By default, [Linguist classifies the `samples` folder as documentation](https://github.com/github/linguist/blob/master/lib/linguist/documentation.yml#L33), meaning it is not counted in the repository's language stats. This PR overrides that classification and fixes the language stats.

Before:
![grafik](https://user-images.githubusercontent.com/33814365/93427299-728c9f00-f872-11ea-99b2-397c0c8e3107.png)

After:
![grafik](https://user-images.githubusercontent.com/33814365/93427322-7c160700-f872-11ea-9e0b-f6af2468ede4.png)
