### PR TITLE
Add visualization sample for %trace and %debug

### DIFF
--- a/binder-index.md
+++ b/binder-index.md
@@ -259,6 +259,14 @@ These are noted in the README.md files for each sample, along with complete inst
       <td>Q# + .NET</td>
     </tr>
     <tr>
+      <td></td>
+      <td><strong><a href="./samples/diagnostics/visualization/README.md">Visualizing quantum programs</a></strong></td>
+      <td><a href="./samples/diagnostics/visualization/Visualizing%20Quantum%20Programs.ipynb">Q# notebook</a></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
       <td><strong>Error correction:</strong></td>
       <td><strong><a href="./samples/error-correction/bit-flip-code/README.md">Bit flip code</a></strong></td>
       <td></td>

--- a/samples/diagnostics/README.md
+++ b/samples/diagnostics/README.md
@@ -2,5 +2,14 @@
 
 These samples show how to diagnose and test Q# applications. 
 
+- **[Dumping States and Operations](./dumping)**:
+  This sample demonstrates how to dump useful diagnostics from the quantum simulator provided with the Quantum Development Kit, including states and unitary matrices.
+
+- **[Using Facts and Assertions](./facts-and-assertions)**:
+  This sample demonstrates how to use facts and assertions to check the correctness of quantum programs.
+
 - **[Unit Testing](./unit-testing)**:
   This sample demonstrates how to use the unit testing functionality provided with the Quantum Development Kit to test the correctness of quantum programs.
+
+- **[Visualizing Quantum Programs](./visualization)**:
+  This sample demonstrates how to use the quantum program visualization tools provided with the Quantum Development Kit.

--- a/samples/diagnostics/dumping/Dumping States and Operations.ipynb
+++ b/samples/diagnostics/dumping/Dumping States and Operations.ipynb
@@ -18,53 +18,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the Microsoft.Quantum.Standard.Visualization package to provide additional visualization support for the diagnostics in this notebook."
+    "We'll first open the [Microsoft.Quantum.Diagnostics namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics) so that its functions and operations are available throughout the notebook."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/json": "{\"LastUpdated\":\"2020-08-26T09:39:52.2294341-07:00\",\"IsCompleted\":true,\"Description\":\"Adding package Microsoft.Quantum.Standard.Visualization\",\"Subtask\":\"done\"}",
-      "text/plain": [
-       "Adding package Microsoft.Quantum.Standard.Visualization: done!"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/json": "[\"Microsoft.Quantum.Standard::0.12.20082513\",\"Microsoft.Quantum.Standard.Visualization::0.12.20082513\"]",
-      "text/html": [
-       "<ul><li>Microsoft.Quantum.Standard::0.12.20082513</li><li>Microsoft.Quantum.Standard.Visualization::0.12.20082513</li></ul>"
-      ],
-      "text/plain": [
-       "Microsoft.Quantum.Standard::0.12.20082513, Microsoft.Quantum.Standard.Visualization::0.12.20082513"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%package Microsoft.Quantum.Standard.Visualization"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For convinence, we'll also open the [Microsoft.Quantum.Diagnostics namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics) so that its functions and operations are available throughout the notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -75,7 +34,7 @@
       ],
       "text/plain": []
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -102,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +74,7 @@
        "DumpEntangledState"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -136,12 +95,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"QubitIds\":[0,1,2,3],\"NQubits\":4,\"Amplitudes\":[{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0}]}",
+      "application/json": "{\"div_id\":\"dump-machine-div-6bcee08b-9b38-46ae-8edf-918dfa93a371\",\"qubit_ids\":[0,1,2,3],\"n_qubits\":4,\"amplitudes\":[{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0}]}",
       "text/html": [
        "\r\n",
        "                    <table style=\"table-layout: fixed; width: 100%\">\r\n",
@@ -154,24 +113,32 @@
        "                    \r\n",
        "                            <tr>\r\n",
        "                                <th style=\"width: 20ch)\">Basis state (little endian)</th>\r\n",
-       "                                <th style=\"width: 20ch\">Amplitude</th>\r\n",
-       "                                <th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th>\r\n",
-       "                                <th style=\"width: 6ch\">Phase</th>\r\n",
+       "                                <th style=\"width: 20ch\">Amplitude</th><th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th><th style=\"width: 6ch\">Phase</th>\r\n",
        "                            </tr>\r\n",
        "                        </thead>\r\n",
-       "\r\n",
        "                        <tbody>\r\n",
-       "                            \r\n",
+       "                        \r\n",
        "                            <tr>\r\n",
        "                                <td>$\\left|0\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-3915ded2-2fbb-44ae-8645-f793a144b5b7\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-3915ded2-2fbb-44ae-8645-f793a144b5b7\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -184,13 +151,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|1\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-4360df61-0006-49ce-9ecc-fd50ee9fd065\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-4360df61-0006-49ce-9ecc-fd50ee9fd065\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -203,13 +181,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|2\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-af9ea67b-1fad-4240-8bd9-210c6826b035\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-af9ea67b-1fad-4240-8bd9-210c6826b035\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -222,13 +211,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|3\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-1f030009-8f7b-47aa-8652-4b950854556f\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-1f030009-8f7b-47aa-8652-4b950854556f\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -241,13 +241,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|4\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-f11e811c-d5e7-40d6-9398-154e1cfe5ea7\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-f11e811c-d5e7-40d6-9398-154e1cfe5ea7\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -260,13 +271,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|5\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-e4b3fa02-bd0a-401d-9de1-d127ff935d34\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-e4b3fa02-bd0a-401d-9de1-d127ff935d34\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -279,13 +301,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|6\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-9c6f3e5b-2d7d-4238-b158-8ae51c256a49\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-9c6f3e5b-2d7d-4238-b158-8ae51c256a49\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -298,13 +331,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|7\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-9dd8109d-76bc-4563-ba8e-9d583a58caf1\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-9dd8109d-76bc-4563-ba8e-9d583a58caf1\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -317,13 +361,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|8\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-ce2eb432-3163-44e6-824f-66d5543ee18a\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-ce2eb432-3163-44e6-824f-66d5543ee18a\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -336,13 +391,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|9\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-cb087aed-b827-49e6-853e-e14cd48fe2cf\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-cb087aed-b827-49e6-853e-e14cd48fe2cf\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -355,13 +421,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|10\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-62650336-32c4-4e1e-9dba-5756ab744eac\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-62650336-32c4-4e1e-9dba-5756ab744eac\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -374,13 +451,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|11\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-ddb4a964-feac-4b20-85dc-e2ddcaaf8c44\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-ddb4a964-feac-4b20-85dc-e2ddcaaf8c44\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -393,13 +481,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|12\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-f436ad8d-85c7-42d8-b649-8c28482778f9\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-f436ad8d-85c7-42d8-b649-8c28482778f9\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -412,13 +511,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|13\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-21bd7931-6800-4b81-9efb-a60032a8f76b\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-21bd7931-6800-4b81-9efb-a60032a8f76b\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -431,13 +541,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|14\\right\\rangle$</td>\r\n",
        "                                <td>$0.0000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"0\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-e209b4b4-5f46-4610-af72-801de187ae94\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 0;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-e209b4b4-5f46-4610-af72-801de187ae94\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -450,13 +571,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|15\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-2b6a76c4-bc42-4241-b616-680565fdb178\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-2b6a76c4-bc42-4241-b616-680565fdb178\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -466,8 +598,7 @@
        "                            </tr>\r\n",
        "                        \r\n",
        "                        </tbody>\r\n",
-       "                    </table>\r\n",
-       "                "
+       "                    </table>"
       ],
       "text/plain": [
        "|0⟩\t0.5000000000000001 + 0𝑖\n",
@@ -498,7 +629,7 @@
        "()"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,7 +650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -529,7 +660,7 @@
        "\"bitstring\""
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -541,12 +672,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"QubitIds\":[0,1,2,3],\"NQubits\":4,\"Amplitudes\":[{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0}]}",
+      "application/json": "{\"div_id\":\"dump-machine-div-2980a403-b166-4c1f-8c38-e26635520141\",\"qubit_ids\":[0,1,2,3],\"n_qubits\":4,\"amplitudes\":[{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":0.0,\"Magnitude\":0.0,\"Phase\":0.0},{\"Real\":0.5000000000000001,\"Imaginary\":0.0,\"Magnitude\":0.5000000000000001,\"Phase\":0.0}]}",
       "text/html": [
        "\r\n",
        "                    <table style=\"table-layout: fixed; width: 100%\">\r\n",
@@ -559,24 +690,32 @@
        "                    \r\n",
        "                            <tr>\r\n",
        "                                <th style=\"width: 20ch)\">Basis state (bitstring)</th>\r\n",
-       "                                <th style=\"width: 20ch\">Amplitude</th>\r\n",
-       "                                <th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th>\r\n",
-       "                                <th style=\"width: 6ch\">Phase</th>\r\n",
+       "                                <th style=\"width: 20ch\">Amplitude</th><th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th><th style=\"width: 6ch\">Phase</th>\r\n",
        "                            </tr>\r\n",
        "                        </thead>\r\n",
-       "\r\n",
        "                        <tbody>\r\n",
-       "                            \r\n",
+       "                        \r\n",
        "                            <tr>\r\n",
        "                                <td>$\\left|0000\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-fbf73d84-47fa-4033-a76f-37701eaf263d\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-fbf73d84-47fa-4033-a76f-37701eaf263d\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -589,13 +728,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|0101\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-7c5421d5-2629-49f0-bd7a-354e4426b8c2\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-7c5421d5-2629-49f0-bd7a-354e4426b8c2\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -608,13 +758,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|1010\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-49ec0b31-0db1-43f2-ad90-2ffaea5b885c\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-49ec0b31-0db1-43f2-ad90-2ffaea5b885c\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -627,13 +788,24 @@
        "                            <tr>\r\n",
        "                                <td>$\\left|1111\\right\\rangle$</td>\r\n",
        "                                <td>$0.5000 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
        "                                <td>\r\n",
        "                                    <progress\r\n",
        "                                        max=\"100\"\r\n",
        "                                        value=\"25.00000000000001\"\r\n",
        "                                        style=\"width: 100%;\"\r\n",
-       "                                    >\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-b6d00653-9f6b-4c81-a1da-9354044bc974\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 25.00000000000001;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-b6d00653-9f6b-4c81-a1da-9354044bc974\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
        "                                </td>\r\n",
+       "                            \r\n",
        "                                \r\n",
        "                                <td style=\"transform: rotate(0deg);\r\n",
        "                   text-align: center;\">\r\n",
@@ -643,8 +815,7 @@
        "                            </tr>\r\n",
        "                        \r\n",
        "                        </tbody>\r\n",
-       "                    </table>\r\n",
-       "                "
+       "                    </table>"
       ],
       "text/plain": [
        "|0000⟩\t0.5000000000000001 + 0𝑖\n",
@@ -663,7 +834,7 @@
        "()"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -681,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -697,7 +868,7 @@
        "dump.basisStateLabelingConvention \"bitstring\"\r\n"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -722,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -735,7 +906,7 @@
        "DumpCnot"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -748,7 +919,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -798,7 +969,7 @@
        "()"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -809,7 +980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -822,7 +993,7 @@
        "DumpSwap"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -835,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -885,7 +1056,7 @@
        "()"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -896,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -909,7 +1080,7 @@
        "DumpT"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -922,7 +1093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -966,7 +1137,7 @@
        "()"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -984,19 +1155,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"rows\":[{\"@type\":\"@tuple\",\"Item1\":\"iqsharp\",\"Item2\":\"0.12.20082513\"},{\"@type\":\"@tuple\",\"Item1\":\"Jupyter Core\",\"Item2\":\"1.4.0.0\"},{\"@type\":\"@tuple\",\"Item1\":\".NET Runtime\",\"Item2\":\".NETCoreApp,Version=v3.1\"}]}",
+      "application/json": "{\"rows\":[{\"@type\":\"@tuple\",\"Item1\":\"iqsharp\",\"Item2\":\"0.13.20102604\"},{\"@type\":\"@tuple\",\"Item1\":\"Jupyter Core\",\"Item2\":\"1.4.0.0\"},{\"@type\":\"@tuple\",\"Item1\":\".NET Runtime\",\"Item2\":\".NETCoreApp,Version=v3.1\"}]}",
       "text/html": [
-       "<table><thead><tr><th style=\"text-align: start;\">Component</th><th style=\"text-align: start;\">Version</th></tr></thead><tbody><tr><td style=\"text-align: start;\">iqsharp</td><td style=\"text-align: start;\">0.12.20082513</td></tr><tr><td style=\"text-align: start;\">Jupyter Core</td><td style=\"text-align: start;\">1.4.0.0</td></tr><tr><td style=\"text-align: start;\">.NET Runtime</td><td style=\"text-align: start;\">.NETCoreApp,Version=v3.1</td></tr></tbody></table>"
+       "<table><thead><tr><th style=\"text-align: start;\">Component</th><th style=\"text-align: start;\">Version</th></tr></thead><tbody><tr><td style=\"text-align: start;\">iqsharp</td><td style=\"text-align: start;\">0.13.20102604</td></tr><tr><td style=\"text-align: start;\">Jupyter Core</td><td style=\"text-align: start;\">1.4.0.0</td></tr><tr><td style=\"text-align: start;\">.NET Runtime</td><td style=\"text-align: start;\">.NETCoreApp,Version=v3.1</td></tr></tbody></table>"
       ],
       "text/plain": [
        "Component    Version\r\n",
        "------------ ------------------------\r\n",
-       "iqsharp      0.12.20082513\r\n",
+       "iqsharp      0.13.20102604\r\n",
        "Jupyter Core 1.4.0.0\r\n",
        ".NET Runtime .NETCoreApp,Version=v3.1\r\n"
       ]
@@ -1008,13 +1179,6 @@
    "source": [
     "%version"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/samples/diagnostics/facts-and-assertions/Facts and Assertions.ipynb
+++ b/samples/diagnostics/facts-and-assertions/Facts and Assertions.ipynb
@@ -304,6 +304,7 @@
     "        PrepareEntangledPair(left, right);\n",
     "        let actual = Measure([PauliZ, PauliZ], [left, right]);\n",
     "        EqualityFactR(actual, Zero, \"Parity of (|00⟩ + |11⟩) / √2 was not Zero.\");\n",
+    "        ResetAll([left, right]);\n",
     "    }\n",
     "}"
    ]
@@ -315,46 +316,14 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "\r\n",
-       "                    <details>\r\n",
-       "                        <summary>\r\n",
-       "                            Unhandled exception of type Microsoft.Quantum.Simulation.Simulators.Exceptions.ReleasedQubitsAreNotInZeroState: Released qubits are not in zero state.\r\n",
-       "                        </summary>\r\n",
-       "                        <table>\r\n",
-       "                            <thead>\r\n",
-       "                                <tr>\r\n",
-       "                                    <th>Source</th>\r\n",
-       "                                    <th>Callable</th>\r\n",
-       "                                </tr>\r\n",
-       "                            </thead>\r\n",
-       "\r\n",
-       "                            <tbody>\r\n",
-       "                                \r\n",
-       "                        <tr>\r\n",
-       "                            <td>(notebook)</td>\r\n",
-       "                            <td>CheckEntanglementPreparation</td>\r\n",
-       "                        </tr>\r\n",
-       "                    \r\n",
-       "                            </tbody>\r\n",
-       "                        </table>\r\n",
-       "                    </details>\r\n",
-       "                "
-      ],
+      "application/json": "{\"@type\":\"tuple\"}",
       "text/plain": [
-       "Unhandled exception. Microsoft.Quantum.Simulation.Simulators.Exceptions.ReleasedQubitsAreNotInZeroState: Released qubits are not in zero state.\r\n",
-       " ---> SNIPPET.CheckEntanglementPreparation on C:\\snippet_.qs:line 0\r\n"
+       "()"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Released qubits are not in zero state.\r\n"
-     ]
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/samples/diagnostics/facts-and-assertions/Facts and Assertions.ipynb
+++ b/samples/diagnostics/facts-and-assertions/Facts and Assertions.ipynb
@@ -18,53 +18,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the Microsoft.Quantum.Standard.Visualization package to provide additional visualization support for the diagnostics in this notebook."
+    "We'll first open the [Microsoft.Quantum.Diagnostics namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics) so that its functions and operations are available throughout the notebook."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/json": "{\"LastUpdated\":\"2020-08-25T21:25:10.6664721-07:00\",\"IsCompleted\":true,\"Description\":\"Adding package Microsoft.Quantum.Standard.Visualization\",\"Subtask\":\"done\"}",
-      "text/plain": [
-       "Adding package Microsoft.Quantum.Standard.Visualization: done!"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/json": "[\"Microsoft.Quantum.Standard::0.12.20082513\",\"Microsoft.Quantum.Standard.Visualization::0.12.20082513\"]",
-      "text/html": [
-       "<ul><li>Microsoft.Quantum.Standard::0.12.20082513</li><li>Microsoft.Quantum.Standard.Visualization::0.12.20082513</li></ul>"
-      ],
-      "text/plain": [
-       "Microsoft.Quantum.Standard::0.12.20082513, Microsoft.Quantum.Standard.Visualization::0.12.20082513"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%package Microsoft.Quantum.Standard.Visualization"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For convinence, we'll also open the [Microsoft.Quantum.Diagnostics namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics) so that its functions and operations are available throughout the notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -75,7 +34,7 @@
       ],
       "text/plain": []
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -114,7 +73,7 @@
        "AdditionFact"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -137,7 +96,7 @@
        "()"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -183,7 +142,7 @@
        "AdditionContradiction"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -196,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -206,7 +165,7 @@
        "()"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -237,7 +196,7 @@
        "AdditionFact"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -251,12 +210,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"Exception\":{\"StackTrace\":\"   at Microsoft.Quantum.Diagnostics.FormattedFailure`1.<>c.<get_Body>b__7_0(ValueTuple`3 __in__) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\QuantumLibraries\\\\Standard\\\\src\\\\Diagnostics\\\\Internal.qs:line 14\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply[GenO](Object args)\\r\\n   at Microsoft.Quantum.Simulation.Core.GenericCallable.Apply[O](Object args) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\qsharp-runtime\\\\src\\\\Simulation\\\\Core\\\\Generics\\\\GenericCallable.cs:line 122\\r\\n   at Microsoft.Quantum.Simulation.Core.GenericCallable.Microsoft.Quantum.Simulation.Core.ICallable.Apply(Object args) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\qsharp-runtime\\\\src\\\\Simulation\\\\Core\\\\Generics\\\\GenericCallable.cs:line 135\\r\\n   at Microsoft.Quantum.Diagnostics.EqualityFactI.<get_Body>b__11_0(ValueTuple`3 __in__) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\QuantumLibraries\\\\Standard\\\\src\\\\Diagnostics\\\\Facts.qs:line 93\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Microsoft.Quantum.Simulation.Core.ICallable<I,O>.Apply(I args)\\r\\n   at SNIPPET.AdditionFact.<get_Body>b__10_0(QVoid __in__)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply[GenO](Object args)\\r\\n   at Microsoft.Quantum.Simulation.Common.SimulatorBase.Execute[T,I,O](I args) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\qsharp-runtime\\\\src\\\\Simulation\\\\Common\\\\SimulatorBase.cs:line 156\",\"Message\":\"addition fact failed\\n\\tExpected:\\t6\\n\\tActual:\\t5\",\"Data\":{},\"InnerException\":null,\"HelpLink\":null,\"Source\":\"Microsoft.Quantum.Standard\",\"HResult\":-2146233088},\"StackTrace\":null,\"Header\":\"Unhandled exception. Microsoft.Quantum.Simulation.Core.ExecutionFailException: addition fact failed\\n\\tExpected:\\t6\\n\\tActual:\\t5\"}",
+      "application/json": "{\"Exception\":{\"StackTrace\":\"   at Microsoft.Quantum.Diagnostics.FormattedFailure`1.<>c.<get___Body__>b__7_0(ValueTuple`3 __in__) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\QuantumLibraries\\\\Standard\\\\src\\\\Diagnostics\\\\Internal.qs:line 14\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply[GenO](Object args)\\r\\n   at Microsoft.Quantum.Simulation.Core.GenericCallable.Apply[O](Object args)\\r\\n   at Microsoft.Quantum.Simulation.Core.GenericCallable.Microsoft.Quantum.Simulation.Core.ICallable.Apply(Object args)\\r\\n   at Microsoft.Quantum.Diagnostics.EqualityFactI.<get___Body__>b__11_0(ValueTuple`3 __in__) in D:\\\\a\\\\1\\\\s\\\\submodules\\\\QuantumLibraries\\\\Standard\\\\src\\\\Diagnostics\\\\Facts.qs:line 93\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Microsoft.Quantum.Simulation.Core.ICallable<I,O>.Apply(I args)\\r\\n   at SNIPPET.AdditionFact.<get___Body__>b__10_0(QVoid __in__)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply(I a)\\r\\n   at Microsoft.Quantum.Simulation.Core.Function`2.Apply[GenO](Object args)\\r\\n   at Microsoft.Quantum.Simulation.Common.SimulatorBase.Execute[T,I,O](I args)\",\"Message\":\"addition fact failed\\n\\tExpected:\\t6\\n\\tActual:\\t5\",\"Data\":{},\"InnerException\":null,\"HelpLink\":null,\"Source\":\"Microsoft.Quantum.Standard\",\"HResult\":-2146233088},\"StackTrace\":null,\"Header\":\"Unhandled exception. Microsoft.Quantum.Simulation.Core.ExecutionFailException: addition fact failed\\n\\tExpected:\\t6\\n\\tActual:\\t5\"}",
       "text/plain": [
        "Microsoft.Quantum.IQSharp.DisplayableException"
       ]
@@ -287,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -300,7 +259,7 @@
        "PrepareEntangledPair"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -321,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +293,7 @@
        "CheckEntanglementPreparation"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,19 +310,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"@type\":\"tuple\"}",
+      "text/html": [
+       "\r\n",
+       "                    <details>\r\n",
+       "                        <summary>\r\n",
+       "                            Unhandled exception of type Microsoft.Quantum.Simulation.Simulators.Exceptions.ReleasedQubitsAreNotInZeroState: Released qubits are not in zero state.\r\n",
+       "                        </summary>\r\n",
+       "                        <table>\r\n",
+       "                            <thead>\r\n",
+       "                                <tr>\r\n",
+       "                                    <th>Source</th>\r\n",
+       "                                    <th>Callable</th>\r\n",
+       "                                </tr>\r\n",
+       "                            </thead>\r\n",
+       "\r\n",
+       "                            <tbody>\r\n",
+       "                                \r\n",
+       "                        <tr>\r\n",
+       "                            <td>(notebook)</td>\r\n",
+       "                            <td>CheckEntanglementPreparation</td>\r\n",
+       "                        </tr>\r\n",
+       "                    \r\n",
+       "                            </tbody>\r\n",
+       "                        </table>\r\n",
+       "                    </details>\r\n",
+       "                "
+      ],
       "text/plain": [
-       "()"
+       "Unhandled exception. Microsoft.Quantum.Simulation.Simulators.Exceptions.ReleasedQubitsAreNotInZeroState: Released qubits are not in zero state.\r\n",
+       " ---> SNIPPET.CheckEntanglementPreparation on C:\\snippet_.qs:line 0\r\n"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Released qubits are not in zero state.\r\n"
+     ]
     }
    ],
    "source": [
@@ -395,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +399,7 @@
        "CheckFreshQubitIsInZero"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +424,7 @@
        "()"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -470,7 +461,7 @@
        "CheckHPreparesPlus"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -488,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -498,7 +489,7 @@
        "()"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -518,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -531,7 +522,7 @@
        "ApplyCnotDirectly, ApplyCnotWithinH"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -552,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -565,7 +556,7 @@
        "CheckCnotIdentity"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -581,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -591,7 +582,7 @@
        "()"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -609,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -622,7 +613,7 @@
        "CheckFreshQubitIsInZero"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -637,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -647,7 +638,7 @@
        "()"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -672,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -685,7 +676,7 @@
        "CheckNoLargeRegistersAllocated"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -704,7 +695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {
     "scrolled": true
    },
@@ -769,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -782,7 +773,7 @@
        "CheckHNotCalled"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -802,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -859,19 +850,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/json": "{\"rows\":[{\"@type\":\"@tuple\",\"Item1\":\"iqsharp\",\"Item2\":\"0.12.20082513\"},{\"@type\":\"@tuple\",\"Item1\":\"Jupyter Core\",\"Item2\":\"1.4.0.0\"},{\"@type\":\"@tuple\",\"Item1\":\".NET Runtime\",\"Item2\":\".NETCoreApp,Version=v3.1\"}]}",
+      "application/json": "{\"rows\":[{\"@type\":\"@tuple\",\"Item1\":\"iqsharp\",\"Item2\":\"0.13.20102604\"},{\"@type\":\"@tuple\",\"Item1\":\"Jupyter Core\",\"Item2\":\"1.4.0.0\"},{\"@type\":\"@tuple\",\"Item1\":\".NET Runtime\",\"Item2\":\".NETCoreApp,Version=v3.1\"}]}",
       "text/html": [
-       "<table><thead><tr><th style=\"text-align: start;\">Component</th><th style=\"text-align: start;\">Version</th></tr></thead><tbody><tr><td style=\"text-align: start;\">iqsharp</td><td style=\"text-align: start;\">0.12.20082513</td></tr><tr><td style=\"text-align: start;\">Jupyter Core</td><td style=\"text-align: start;\">1.4.0.0</td></tr><tr><td style=\"text-align: start;\">.NET Runtime</td><td style=\"text-align: start;\">.NETCoreApp,Version=v3.1</td></tr></tbody></table>"
+       "<table><thead><tr><th style=\"text-align: start;\">Component</th><th style=\"text-align: start;\">Version</th></tr></thead><tbody><tr><td style=\"text-align: start;\">iqsharp</td><td style=\"text-align: start;\">0.13.20102604</td></tr><tr><td style=\"text-align: start;\">Jupyter Core</td><td style=\"text-align: start;\">1.4.0.0</td></tr><tr><td style=\"text-align: start;\">.NET Runtime</td><td style=\"text-align: start;\">.NETCoreApp,Version=v3.1</td></tr></tbody></table>"
       ],
       "text/plain": [
        "Component    Version\r\n",
        "------------ ------------------------\r\n",
-       "iqsharp      0.12.20082513\r\n",
+       "iqsharp      0.13.20102604\r\n",
        "Jupyter Core 1.4.0.0\r\n",
        ".NET Runtime .NETCoreApp,Version=v3.1\r\n"
       ]
@@ -883,13 +874,6 @@
    "source": [
     "%version"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/samples/diagnostics/visualization/README.md
+++ b/samples/diagnostics/visualization/README.md
@@ -1,0 +1,54 @@
+---
+page_type: sample
+languages:
+- qsharp
+products:
+- qdk
+description: "Visualizing quantum programs in Q# notebooks."
+urlFragment: visualization
+jupyter:
+  jupytext:
+    cell_markers: region,endregion
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.2'
+      jupytext_version: 1.5.2
+  kernelspec:
+    display_name: .NET (PowerShell)
+    language: PowerShell
+    name: .net-powershell
+---
+
+# Visualizing Quantum Programs
+
+This sample demonstrates:
+
+- Using `%trace` to visualize the execution path of a Q# program.
+- Using `%debug` to step through the execution of a Q# program.
+
+In this sample, you can use the `%trace` and `%debug` magic commands provided in Q# notebooks to visualize the execution path of a Q# program and to analyze the state of the quantum registers at each step of the program.
+
+## Prerequisites
+
+- The Microsoft [Quantum Development Kit](https://docs.microsoft.com/quantum/install-guide/).
+
+## Running the Sample
+
+This sample is designed to be run from Jupyter Notebook.
+To set up your development environment to run Jupyter Notebooks, follow the steps explained in the [Q# Quickstart: Jupyter guide](https://docs.microsoft.com/quantum/quickstarts/install-jupyter).
+
+Once this is set up, from the terminal, you can run the following command:
+
+```Command Line
+jupyter notebook
+```
+
+## Manifest
+
+- [Visualizing Quantum Programs.ipynb](https://github.com/microsoft/Quantum/blob/main/samples/diagnostics/visualization/Visualizing%20Quantum%20Programs.ipynb): Main Q# notebook for this sample.
+
+## Further resources
+
+- [`%trace` magic command documentation](https://docs.microsoft.com/qsharp/api/iqsharp-magic/trace)
+- [`%debug` magic command documentation](https://docs.microsoft.com/qsharp/api/iqsharp-magic/debug)

--- a/samples/diagnostics/visualization/Visualizing Quantum Programs.ipynb
+++ b/samples/diagnostics/visualization/Visualizing Quantum Programs.ipynb
@@ -1,0 +1,989 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quantum Development Kit Samples<br>Diagnostics: Visualizing Quantum Programs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preamble"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll first open the [Microsoft.Quantum.Diagnostics namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics) so that its functions and operations are available throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[]",
+      "text/html": [
+       "<ul></ul>"
+      ],
+      "text/plain": []
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "open Microsoft.Quantum.Diagnostics;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is a quantum program?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Quantum programs are really **classical programs** that can send instructions to and get measurement results back from simulators and quantum devices."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an example of this, **Q#** is a classical language designed to make it easier to write, test, and run quantum programs:\n",
+    "\n",
+    "- High-level\n",
+    "- Focused on algorithms\n",
+    "- Portable across simulators and hardware\n",
+    "- Quantum-focused features\n",
+    "- Diagnostics to help test and understand\n",
+    "\n",
+    "Q# is part of the **Microsoft Quantum Development Kit (QDK)**: [aka.ms/get-started-qdk](https://aka.ms/get-started-qdk)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why is visualization important for quantum programs?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When running algorithms on quantum hardware, we **cannot observe the quantum state** prior to measurement.\n",
+    "\n",
+    "Even when running in a simulator, it may be **hard to gain intuition about the state** purely from wavefunction amplitudes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Visualization helps with intuition** and may make it easier to:\n",
+    "- understand the behavior of a quantum algorithm\n",
+    "- identify bugs in its implementation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example: Teleportation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Quantum teleportation** is a textbook example of a simple quantum algorithm.\n",
+    "\n",
+    "It uses **entanglement and measurements** to \"teleport\" the exact quantum state of a source qubit to a target qubit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's use this algorithm to demonstrate a number of visualization techniques provided by Q# and the QDK:\n",
+    "\n",
+    "   - visualizing quantum **operations**\n",
+    "   - visualizing quantum **states**\n",
+    "   - visualizing an **execution path** for a quantum algorithm\n",
+    "   - visualizing the **step-by-step operation** of a quantum program"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing a Q# operation using `DumpOperation`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We begin by **defining a Q# operation** called `PrepareEntangledState`.\n",
+    "\n",
+    "We can **visualize this operation as a unitary matrix** by using `DumpOperation`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[\"PrepareEntangledState\",\"VisualizePrepareEntangledState\"]",
+      "text/html": [
+       "<ul><li>PrepareEntangledState</li><li>VisualizePrepareEntangledState</li></ul>"
+      ],
+      "text/plain": [
+       "PrepareEntangledState, VisualizePrepareEntangledState"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operation PrepareEntangledState(qubits : Qubit[]) : Unit is Adj {\n",
+    "    H(qubits[0]);\n",
+    "    CNOT(qubits[0], qubits[1]);\n",
+    "}\n",
+    "\n",
+    "operation VisualizePrepareEntangledState() : Unit {\n",
+    "    DumpOperation(2, PrepareEntangledState);\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "                    <table>\r\n",
+       "                        <tr>\r\n",
+       "                            <th>Qubit IDs</th>\r\n",
+       "                            <td>2, 3\r\n",
+       "                        </tr>\r\n",
+       "\r\n",
+       "                        <tr>\r\n",
+       "                            <th>Unitary representation</th>\r\n",
+       "                            <td>$$\r\n",
+       "                                \\left(\\begin{matrix}\r\n",
+       "                                    0.707 & 0.707 & 0 & 0 \\\\\n",
+       "0 & 0 & 0.707 & -0.707 \\\\\n",
+       "0 & 0 & 0.707 & 0.707 \\\\\n",
+       "0.707 & -0.707 & 0 & 0\r\n",
+       "                                \\end{matrix}\\right)\r\n",
+       "                            $$</td>\r\n",
+       "                        </tr>\r\n",
+       "                    </table>\r\n",
+       "                "
+      ],
+      "text/plain": [
+       "Real:\n",
+       "[[0.7071067811865477, 0.7071067811865477, 0, 0], \r\n",
+       "[0, 0, 0.7071067811865477, -0.7071067811865477], \r\n",
+       "[0, 0, 0.7071067811865477, 0.7071067811865477], \r\n",
+       "[0.7071067811865477, -0.7071067811865477, 0, 0]]\n",
+       "Imag:\n",
+       "[[0, 0, 0, 0], \r\n",
+       "[0, 0, 0, 0], \r\n",
+       "[0, 0, 0, 0], \r\n",
+       "[0, 0, 0, 0]]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/json": "{\"@type\":\"tuple\"}",
+      "text/plain": [
+       "()"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%simulate VisualizePrepareEntangledState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing quantum states within `Teleport` using `DumpRegister`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[\"Teleport\"]",
+      "text/html": [
+       "<ul><li>Teleport</li></ul>"
+      ],
+      "text/plain": [
+       "Teleport"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "open Microsoft.Quantum.Math;\n",
+    "open Microsoft.Quantum.Random;\n",
+    "\n",
+    "operation Teleport() : Unit {\n",
+    "    using ((source, intermediate, target) = (Qubit(), Qubit(), Qubit())) {\n",
+    "    \n",
+    "        // Store a random message in the source qubit and visualize its state.\n",
+    "        let randomAngle = DrawRandomDouble(0.0, 2.0*PI());\n",
+    "        Rx(randomAngle, source);\n",
+    "        Message(\"State of source qubit:\");\n",
+    "        DumpRegister((), [source]);\n",
+    "    \n",
+    "        // Create some entanglement that we can use to send our message.\n",
+    "        PrepareEntangledState([intermediate, target]);\n",
+    "\n",
+    "        // Entangle the source qubit with the intermediate qubit.\n",
+    "        CNOT(source, intermediate);\n",
+    "        H(source);\n",
+    "\n",
+    "        // Measure the qubits and decode the message by applying corrections on the target qubit.\n",
+    "        if (M(source) == One) { Z(target); }\n",
+    "        if (M(intermediate) == One) { X(target); }\n",
+    "        \n",
+    "        // Visualize the current state of the target qubit.\n",
+    "        Message(\"State of target qubit:\");\n",
+    "        DumpRegister((), [target]);\n",
+    "        Reset(target);\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we now simulate the `Teleport` operation, we can **verify that the quantum state is teleported correctly** each time it is run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State of source qubit:\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "{\"div_id\":\"dump-machine-div-c2933fe5-97e2-4dc2-bf4c-589cb4b942ab\",\"qubit_ids\":[0],\"n_qubits\":1,\"amplitudes\":[{\"Real\":0.9198280183216668,\"Imaginary\":0.0,\"Magnitude\":0.9198280183216668,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":-0.39232182798110443,\"Magnitude\":0.39232182798110443,\"Phase\":-1.5707963267948966}]}",
+      "text/html": [
+       "\r\n",
+       "                    <table style=\"table-layout: fixed; width: 100%\">\r\n",
+       "                        <thead>\r\n",
+       "                            \r\n",
+       "                        <tr>\r\n",
+       "                            <th>Qubit IDs</th>\r\n",
+       "                            <td span=\"3\">0</td>\r\n",
+       "                        </tr>\r\n",
+       "                    \r\n",
+       "                            <tr>\r\n",
+       "                                <th style=\"width: 20ch)\">Basis state (little endian)</th>\r\n",
+       "                                <th style=\"width: 20ch\">Amplitude</th><th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th><th style=\"width: 6ch\">Phase</th>\r\n",
+       "                            </tr>\r\n",
+       "                        </thead>\r\n",
+       "                        <tbody>\r\n",
+       "                        \r\n",
+       "                            <tr>\r\n",
+       "                                <td>$\\left|0\\right\\rangle$</td>\r\n",
+       "                                <td>$0.9198 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
+       "                                <td>\r\n",
+       "                                    <progress\r\n",
+       "                                        max=\"100\"\r\n",
+       "                                        value=\"84.60835832895647\"\r\n",
+       "                                        style=\"width: 100%;\"\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-ca43b7ba-2802-42ee-ad7f-bebeeda0d990\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 84.60835832895647;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-ca43b7ba-2802-42ee-ad7f-bebeeda0d990\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                                \r\n",
+       "                                <td style=\"transform: rotate(0deg);\r\n",
+       "                   text-align: center;\">\r\n",
+       "                                 ↑\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                            </tr>\r\n",
+       "                        \n",
+       "\r\n",
+       "                            <tr>\r\n",
+       "                                <td>$\\left|1\\right\\rangle$</td>\r\n",
+       "                                <td>$0.0000  -0.3923 i$</td>\r\n",
+       "                                \r\n",
+       "                                <td>\r\n",
+       "                                    <progress\r\n",
+       "                                        max=\"100\"\r\n",
+       "                                        value=\"15.39164167104353\"\r\n",
+       "                                        style=\"width: 100%;\"\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-8dde1787-e53e-4841-8de3-08c3f1616585\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 15.39164167104353;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-8dde1787-e53e-4841-8de3-08c3f1616585\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                                \r\n",
+       "                                <td style=\"transform: rotate(-90deg);\r\n",
+       "                   text-align: center;\">\r\n",
+       "                                 ↑\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                            </tr>\r\n",
+       "                        \r\n",
+       "                        </tbody>\r\n",
+       "                    </table>"
+      ],
+      "text/plain": [
+       "|0⟩\t0.9198280183216668 + 0𝑖\n",
+       "|1⟩\t0 + -0.39232182798110443𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State of target qubit:\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "{\"div_id\":\"dump-machine-div-15340045-dd38-4fcd-9b38-9540439623ea\",\"qubit_ids\":[2],\"n_qubits\":1,\"amplitudes\":[{\"Real\":0.9198280183216668,\"Imaginary\":0.0,\"Magnitude\":0.9198280183216668,\"Phase\":0.0},{\"Real\":0.0,\"Imaginary\":-0.39232182798110454,\"Magnitude\":0.39232182798110454,\"Phase\":-1.5707963267948966}]}",
+      "text/html": [
+       "\r\n",
+       "                    <table style=\"table-layout: fixed; width: 100%\">\r\n",
+       "                        <thead>\r\n",
+       "                            \r\n",
+       "                        <tr>\r\n",
+       "                            <th>Qubit IDs</th>\r\n",
+       "                            <td span=\"3\">2</td>\r\n",
+       "                        </tr>\r\n",
+       "                    \r\n",
+       "                            <tr>\r\n",
+       "                                <th style=\"width: 20ch)\">Basis state (little endian)</th>\r\n",
+       "                                <th style=\"width: 20ch\">Amplitude</th><th style=\"width: calc(100% - 26ch - 20ch)\">Meas. Pr.</th><th style=\"width: 6ch\">Phase</th>\r\n",
+       "                            </tr>\r\n",
+       "                        </thead>\r\n",
+       "                        <tbody>\r\n",
+       "                        \r\n",
+       "                            <tr>\r\n",
+       "                                <td>$\\left|0\\right\\rangle$</td>\r\n",
+       "                                <td>$0.9198 + 0.0000 i$</td>\r\n",
+       "                                \r\n",
+       "                                <td>\r\n",
+       "                                    <progress\r\n",
+       "                                        max=\"100\"\r\n",
+       "                                        value=\"84.60835832895647\"\r\n",
+       "                                        style=\"width: 100%;\"\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-d98787db-591f-4203-983b-6cae81f3718a\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 84.60835832895647;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-d98787db-591f-4203-983b-6cae81f3718a\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                                \r\n",
+       "                                <td style=\"transform: rotate(0deg);\r\n",
+       "                   text-align: center;\">\r\n",
+       "                                 ↑\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                            </tr>\r\n",
+       "                        \n",
+       "\r\n",
+       "                            <tr>\r\n",
+       "                                <td>$\\left|1\\right\\rangle$</td>\r\n",
+       "                                <td>$0.0000  -0.3923 i$</td>\r\n",
+       "                                \r\n",
+       "                                <td>\r\n",
+       "                                    <progress\r\n",
+       "                                        max=\"100\"\r\n",
+       "                                        value=\"15.391641671043537\"\r\n",
+       "                                        style=\"width: 100%;\"\r\n",
+       "                                    > \r\n",
+       "                                    <td>\r\n",
+       "                                    <p id=\"round-e018ee3d-9c8d-473e-bd50-72b16ef846d5\"> \r\n",
+       "                                    <script>\r\n",
+       "                                    var num = 15.391641671043537;\r\n",
+       "                                    num = num.toFixed(4);\r\n",
+       "                                    var num_string = num + \"%\";\r\n",
+       "                                     document.getElementById(\"round-e018ee3d-9c8d-473e-bd50-72b16ef846d5\").innerHTML = num_string;\r\n",
+       "                                    </script> </p>\r\n",
+       "                                    </td>\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                                \r\n",
+       "                                <td style=\"transform: rotate(-90deg);\r\n",
+       "                   text-align: center;\">\r\n",
+       "                                 ↑\r\n",
+       "                                </td>\r\n",
+       "                            \r\n",
+       "                            </tr>\r\n",
+       "                        \r\n",
+       "                        </tbody>\r\n",
+       "                    </table>"
+      ],
+      "text/plain": [
+       "|0⟩\t0.9198280183216668 + 0𝑖\n",
+       "|1⟩\t0 + -0.39232182798110454𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/json": "{\"@type\":\"tuple\"}",
+      "text/plain": [
+       "()"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%simulate Teleport"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing an execution path of a Q# operation with `%trace`\n",
+    "\n",
+    "- Q# operations may consist of **complex programming paradigms** (e.g. recursion, loops)\n",
+    "- **Hard to represent** as a quantum circuit\n",
+    "- Visualize an **execution path** instead!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a simple program, the execution path looks exactly like a circuit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[\"MeasureEntangledState\"]",
+      "text/html": [
+       "<ul><li>MeasureEntangledState</li></ul>"
+      ],
+      "text/plain": [
+       "MeasureEntangledState"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operation MeasureEntangledState() : Result[] {\n",
+    "    using (qubits = Qubit[2]) {\n",
+    "        H(qubits[0]);\n",
+    "        CNOT(qubits[0], qubits[1]);\n",
+    "        return [M(qubits[0]), M(qubits[1])];\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-d40fc928-68ce-46d1-8afc-ff42c8f16696' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-d40fc928-68ce-46d1-8afc-ff42c8f16696' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%trace MeasureEntangledState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Complex programs are **modular** and will likely contain **nested operations**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[\"MeasureEntangledStateModular\"]",
+      "text/html": [
+       "<ul><li>MeasureEntangledStateModular</li></ul>"
+      ],
+      "text/plain": [
+       "MeasureEntangledStateModular"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "open Microsoft.Quantum.Arrays;\n",
+    "\n",
+    "operation MeasureEntangledStateModular() : Result[] {\n",
+    "    using (qubits = Qubit[2]) {\n",
+    "        PrepareEntangledState(qubits);\n",
+    "        return ForEach(M, qubits);\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With `%trace`, we can visualize the program at a high level and **zoom in** to each operation as desired:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-5750fceb-604f-4fa8-a5aa-bb13defb4001' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-5750fceb-604f-4fa8-a5aa-bb13defb4001' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%trace MeasureEntangledStateModular"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Execution paths are non-deterministic!\n",
+    "\n",
+    "For example, an operation that uses a **\"repeat-until-success\" loop** may have very different execution paths depending on measurement results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[\"MeasureUntilOne\"]",
+      "text/html": [
+       "<ul><li>MeasureUntilOne</li></ul>"
+      ],
+      "text/plain": [
+       "MeasureUntilOne"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operation MeasureUntilOne() : Unit {\n",
+    "    mutable result = Zero;\n",
+    "    using (q = Qubit()) {\n",
+    "        repeat {\n",
+    "            H(q);\n",
+    "            set result = M(q);\n",
+    "        }\n",
+    "        until (result == One);\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-941a7267-2ece-43de-afb2-97931e1d2a0b' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-941a7267-2ece-43de-afb2-97931e1d2a0b' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%trace MeasureUntilOne"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing an execution path for `Teleport`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The execution path for `Teleport` will differ based on the results of the two measurements.\n",
+    "\n",
+    "By repeating `%trace`, we see that the `X` and `Z` operations **only sometimes occur** on the target qubit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-d5c169d6-6010-43da-abcb-6b13d4e2249e' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-d5c169d6-6010-43da-abcb-6b13d4e2249e' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%trace Teleport"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stepping through a Q# operation with `%debug`\n",
+    "\n",
+    "- Classical programming tools typically have **debuggers**, which run one line of code at a time and allow inspection of variable state at each step.\n",
+    "- For small Q# programs, the `%debug` command allows one to **observe how the quantum state changes** as a quantum program runs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we step through an operation that **prepares and measures an entangled state**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting debug session for MeasureEntangledState...\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='7e80b878-6d84-4651-8bae-23e10261d103' />\"}",
+      "text/html": [
+       "<div id='7e80b878-6d84-4651-8bae-23e10261d103' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-8b47a0b1-9032-416c-8a75-ca377cbdb204' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-8b47a0b1-9032-416c-8a75-ca377cbdb204' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished debug session for MeasureEntangledState.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "[1,1]",
+      "text/html": [
+       "<ul><li>One</li><li>One</li></ul>"
+      ],
+      "text/plain": [
+       "One, One"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%debug MeasureEntangledState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stepping through `Teleport`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we step through the `Teleport` operation, which tracks the quantum state of all three qubits:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting debug session for Teleport...\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='903a21a6-dd08-4ffa-bd26-eaf4938ddb3c' />\"}",
+      "text/html": [
+       "<div id='903a21a6-dd08-4ffa-bd26-eaf4938ddb3c' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/json": "{\"Html\":\"<div id='execution-path-container-c71459ba-9087-4f82-8c67-59d8587c88f5' />\"}",
+      "text/html": [
+       "<div id='execution-path-container-c71459ba-9087-4f82-8c67-59d8587c88f5' />"
+      ],
+      "text/plain": [
+       "Microsoft.Quantum.IQSharp.Jupyter.DisplayableHtmlElement"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished debug session for Teleport.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": "{\"@type\":\"tuple\"}",
+      "text/plain": [
+       "()"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%debug Teleport"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have demonstrated several visualization techniques provided by Q# and the QDK:\n",
+    "\n",
+    "   - visualizing quantum **operations**\n",
+    "   - visualizing quantum **states**\n",
+    "   - visualizing an **execution path** for a quantum algorithm\n",
+    "   - visualizing the **step-by-step operation** of a quantum program\n",
+    "\n",
+    "A **variety of visualization tools** can be useful for quantum programs. Not one-size-fits-all!\n",
+    "\n",
+    "Visualization is an important way for students and researchers to **gain intuition** about quantum algorithms and **understand the operation** of quantum programs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Epilogue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": "{\"rows\":[{\"@type\":\"@tuple\",\"Item1\":\"iqsharp\",\"Item2\":\"0.13.20102604\"},{\"@type\":\"@tuple\",\"Item1\":\"Jupyter Core\",\"Item2\":\"1.4.0.0\"},{\"@type\":\"@tuple\",\"Item1\":\".NET Runtime\",\"Item2\":\".NETCoreApp,Version=v3.1\"}]}",
+      "text/html": [
+       "<table><thead><tr><th style=\"text-align: start;\">Component</th><th style=\"text-align: start;\">Version</th></tr></thead><tbody><tr><td style=\"text-align: start;\">iqsharp</td><td style=\"text-align: start;\">0.13.20102604</td></tr><tr><td style=\"text-align: start;\">Jupyter Core</td><td style=\"text-align: start;\">1.4.0.0</td></tr><tr><td style=\"text-align: start;\">.NET Runtime</td><td style=\"text-align: start;\">.NETCoreApp,Version=v3.1</td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "Component    Version\r\n",
+       "------------ ------------------------\r\n",
+       "iqsharp      0.13.20102604\r\n",
+       "Jupyter Core 1.4.0.0\r\n",
+       ".NET Runtime .NETCoreApp,Version=v3.1\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%version"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Q#",
+   "language": "qsharp",
+   "name": "iqsharp"
+  },
+  "language_info": {
+   "file_extension": ".qs",
+   "mimetype": "text/x-qsharp",
+   "name": "qsharp",
+   "version": "0.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a sample Q# notebook demonstrating `%trace` and `%debug`, along with some `DumpOperation` and `DumpRegister` examples. I know there are already `Dump` examples in another sample, but it seemed logical to me to include some here as well.

I have also updated the other diagnostics notebooks by removing the `%package Microsoft.Quantum.Standard.Visualization` cell, which is no longer necessary with recent IQ# releases, and re-running the notebooks on the latest release.