### PR TITLE
Restore valid base image version

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/microsoft/iqsharp/blob/main/images/iqsharp-base/Dockerfile.
 # As per Binder documentation, we choose to use an SHA sum here instead of a
 # tag.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.201118141-beta
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.20102604
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE


### PR DESCRIPTION
Looks like #437 contained an inadvertent change to `Dockerfile` that broke the Docker image build.

e.g., from https://github.com/microsoft/Quantum/runs/1383424059:
```
Step 1/10 : FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.201118141-beta
manifest for mcr.microsoft.com/quantum/iqsharp-base:0.13.201118141-beta not found: manifest unknown: manifest tagged by "0.13.201118141-beta" is not found
Error response from daemon: No such image: public/quantum/samples:77b68faa38df8a601ba3fcc1ffef3094be242cba
```

This change reverts back to use the previously-released version 0.13.20102604.