### PR TITLE
Update Quantum SDK references to enable local e2e builds after compiler breaking change

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/microsoft/iqsharp/blob/main/images/iqsharp-base/Dockerfile.
 # As per Binder documentation, we choose to use an SHA sum here instead of a
 # tag.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.20102604
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.20111102-beta
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE

--- a/samples/algorithms/chsh-game/CHSHGame.csproj
+++ b/samples/algorithms/chsh-game/CHSHGame.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/database-search/DatabaseSearchSample.csproj
+++ b/samples/algorithms/database-search/DatabaseSearchSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/integer-factorization/IntegerFactorization.csproj
+++ b/samples/algorithms/integer-factorization/IntegerFactorization.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/oracle-synthesis/OracleSynthesis.csproj
+++ b/samples/algorithms/oracle-synthesis/OracleSynthesis.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/order-finding/OrderFinding.csproj
+++ b/samples/algorithms/order-finding/OrderFinding.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/samples/algorithms/repeat-until-success/RepeatUntilSuccess.csproj
+++ b/samples/algorithms/repeat-until-success/RepeatUntilSuccess.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/reversible-logic-synthesis/ReversibleLogicSynthesis.csproj
+++ b/samples/algorithms/reversible-logic-synthesis/ReversibleLogicSynthesis.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/simple-grover/SimpleGroverSample.csproj
+++ b/samples/algorithms/simple-grover/SimpleGroverSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/algorithms/sudoku-grover/SudokuGroverSample.csproj
+++ b/samples/algorithms/sudoku-grover/SudokuGroverSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/characterization/phase-estimation/PhaseEstimationSample.csproj
+++ b/samples/characterization/phase-estimation/PhaseEstimationSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
+++ b/samples/chemistry/AnalyzeHamiltonian/1-AnalyzeHamiltonian.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
 </Project>

--- a/samples/chemistry/CreateHubbardHamiltonian/CreateHubbardHamiltonian.csproj
+++ b/samples/chemistry/CreateHubbardHamiltonian/CreateHubbardHamiltonian.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
 </Project>

--- a/samples/chemistry/GetGateCount/3-GetGateCount.csproj
+++ b/samples/chemistry/GetGateCount/3-GetGateCount.csproj
@@ -1,5 +1,5 @@
 ﻿
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
 </Project>

--- a/samples/chemistry/LithiumHydrideGUI/LithiumHydrideGUI.csproj
+++ b/samples/chemistry/LithiumHydrideGUI/LithiumHydrideGUI.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.20111102-beta" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
 

--- a/samples/chemistry/MolecularHydrogen/MolecularHydrogen.csproj
+++ b/samples/chemistry/MolecularHydrogen/MolecularHydrogen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
 </Project>

--- a/samples/chemistry/MolecularHydrogenGUI/MolecularHydrogenGUI.csproj
+++ b/samples/chemistry/MolecularHydrogenGUI/MolecularHydrogenGUI.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.20111102-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/samples/chemistry/RunSimulation/2-RunSimulation.csproj
+++ b/samples/chemistry/RunSimulation/2-RunSimulation.csproj
@@ -1,5 +1,5 @@
 ﻿
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
-    <PackageReference Include="Microsoft.Quantum.Research" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Research" Version="0.13.20111102-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/chemistry/SimulateHubbardHamiltonian/SimulateHubbardHamiltonian.csproj
+++ b/samples/chemistry/SimulateHubbardHamiltonian/SimulateHubbardHamiltonian.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
 </Project>

--- a/samples/diagnostics/unit-testing/UnitTesting.csproj
+++ b/samples/diagnostics/unit-testing/UnitTesting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/samples/error-correction/bit-flip-code/BitFlipCode.csproj
+++ b/samples/error-correction/bit-flip-code/BitFlipCode.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/error-correction/syndrome/Syndrome.csproj
+++ b/samples/error-correction/syndrome/Syndrome.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/samples/getting-started/measurement/Measurement.csproj
+++ b/samples/getting-started/measurement/Measurement.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/getting-started/qrng/Qrng.csproj
+++ b/samples/getting-started/qrng/Qrng.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/getting-started/simple-algorithms/SimpleAlgorithms.csproj
+++ b/samples/getting-started/simple-algorithms/SimpleAlgorithms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/getting-started/teleportation/TeleportationSample.csproj
+++ b/samples/getting-started/teleportation/TeleportationSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/interoperability/dotnet/qsharp/qsharp.csproj
+++ b/samples/interoperability/dotnet/qsharp/qsharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/samples/interoperability/python/environment.yml
+++ b/samples/interoperability/python/environment.yml
@@ -23,4 +23,4 @@ dependencies:
         - qinfer
         - duecredit
         - mpltools
-        - qsharp==0.13.201118141-beta
+        - qsharp==0.13.20111102b1

--- a/samples/interoperability/qrng/Qrng.csproj
+++ b/samples/interoperability/qrng/Qrng.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/machine-learning/half-moons/HalfMoons.csproj
+++ b/samples/machine-learning/half-moons/HalfMoons.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.20111102-beta" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/machine-learning/half-moons/HalfMoons.ipynb
+++ b/samples/machine-learning/half-moons/HalfMoons.ipynb
@@ -34,7 +34,7 @@
     "plt.style.use('ggplot')\n",
     "\n",
     "import qsharp\n",
-    "qsharp.packages.add(\"Microsoft.Quantum.MachineLearning::0.13.201118141-beta\")\n",
+    "qsharp.packages.add(\"Microsoft.Quantum.MachineLearning::0.13.20111102-beta\")\n",
     "qsharp.reload()\n",
     "\n",
     "from Microsoft.Quantum.Samples import (\n",

--- a/samples/machine-learning/parallel-half-moons/ParallelHalfMoons.csproj
+++ b/samples/machine-learning/parallel-half-moons/ParallelHalfMoons.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.20111102-beta" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/machine-learning/wine/Wine.csproj
+++ b/samples/machine-learning/wine/Wine.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.20111102-beta" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/numerics/CustomModAdd/CustomModAdd.csproj
+++ b/samples/numerics/CustomModAdd/CustomModAdd.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.20111102-beta" />
   </ItemGroup>
 </Project>

--- a/samples/numerics/EvaluatingFunctions/EvaluatingFunctions.csproj
+++ b/samples/numerics/EvaluatingFunctions/EvaluatingFunctions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.20111102-beta" />
   </ItemGroup>
 </Project>

--- a/samples/numerics/ResourceCounting/ResourceCounting.csproj
+++ b/samples/numerics/ResourceCounting/ResourceCounting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.20111102-beta" />
   </ItemGroup>
 </Project>

--- a/samples/runtime/oracle-emulation/OracleEmulation.csproj
+++ b/samples/runtime/oracle-emulation/OracleEmulation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Numerics" Version="0.13.20111102-beta" />
   </ItemGroup>
 </Project>

--- a/samples/runtime/qpic-simulator/host/host.csproj
+++ b/samples/runtime/qpic-simulator/host/host.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <ProjectReference Include="..\simulator\simulator.csproj" />
   </ItemGroup>

--- a/samples/runtime/qpic-simulator/simulator/simulator.csproj
+++ b/samples/runtime/qpic-simulator/simulator/simulator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <OutputType>Library</OutputType>

--- a/samples/runtime/reversible-simulator-advanced/host/host.csproj
+++ b/samples/runtime/reversible-simulator-advanced/host/host.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/samples/runtime/reversible-simulator-advanced/simulator/simulator.csproj
+++ b/samples/runtime/reversible-simulator-advanced/simulator/simulator.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.13.20111102-beta" />
   </ItemGroup>
 </Project>

--- a/samples/runtime/reversible-simulator-simple/ReversibleSimulator.csproj
+++ b/samples/runtime/reversible-simulator-simple/ReversibleSimulator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/samples/runtime/simulator-with-overrides/SimulatorWithOverrides.csproj
+++ b/samples/runtime/simulator-with-overrides/SimulatorWithOverrides.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/h2/command-line/H2SimulationSampleCmdLine.csproj
+++ b/samples/simulation/h2/command-line/H2SimulationSampleCmdLine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/h2/gui/H2SimulationGUI.csproj
+++ b/samples/simulation/h2/gui/H2SimulationGUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/hubbard/HubbardSimulationSample.csproj
+++ b/samples/simulation/hubbard/HubbardSimulationSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/ising/adiabatic/AdiabaticIsingSample.csproj
+++ b/samples/simulation/ising/adiabatic/AdiabaticIsingSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/ising/generators/IsingGeneratorsSample.csproj
+++ b/samples/simulation/ising/generators/IsingGeneratorsSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/ising/phase-estimation/IsingPhaseEstimationSample.csproj
+++ b/samples/simulation/ising/phase-estimation/IsingPhaseEstimationSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/ising/simple/SimpleIsingSample.csproj
+++ b/samples/simulation/ising/simple/SimpleIsingSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/ising/trotter-evolution/IsingTrotterSample.csproj
+++ b/samples/simulation/ising/trotter-evolution/IsingTrotterSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/simulation/qaoa/QAOA.csproj
+++ b/samples/simulation/qaoa/QAOA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/samples/tests/sample-tests/SampleTests.csproj
+++ b/samples/tests/sample-tests/SampleTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
This change updates references to the Quantum SDK such to make them compatible with the latest version of the compiler and enable local e2e builds.