### PR TITLE
Fix Docker image build by pinning pwsh version to avoid .NET SDK incompatibility

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get -y update && \
 # installed. It tends to be more stable to use the .NET Core SDK to do so than
 # to use the Debian package manager, due to issues with syncing libicu
 # dependencies.
-RUN dotnet tool install --global PowerShell
+# Install version 7.0.3, which is the latest version based on .NET Core SDK 3.1.
+RUN dotnet tool install --global PowerShell --version 7.0.3
 
 # Install Jupytext to expose Markdown files as Jupyter Notebooks for use with
 # Binder.


### PR DESCRIPTION
Docker image builds in this repo have started failing with the message:
```
Step 5/10 : RUN dotnet tool install --global PowerShell
 ---> Running in f061533eb52b
error NU1202: Package PowerShell 7.1.0 is not compatible with netcoreapp3.1 (.NETCoreApp,Version=v3.1) / any.
Package PowerShell 7.1.0 supports: net5.0 (.NETCoreApp,Version=v5.0) / any
The tool package could not be restored.
```
For example, see: https://github.com/microsoft/Quantum/runs/1476769834

This PR pins the PowerShell package version to 7.0.3, which is the latest version based on .NET Core SDK 3.1. The released IQ# base image currently installs only .NET Core SDK 3.1 (see the [IQ# Dockerfile here](https://github.com/microsoft/iqsharp/blob/eddc4175aa8df125be440aa9c28b47e7710471b1/images/iqsharp-base/Dockerfile#L50)).
