### PR TITLE
Adjust override sample to account for ongoing refactoring.

### DIFF
--- a/samples/runtime/simulator-with-overrides/FaultyMeasurementsSimulator.cs
+++ b/samples/runtime/simulator-with-overrides/FaultyMeasurementsSimulator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Samples.SimulatorWithOverrides
         /// <summary>
         /// The overriding definition for operation M
         /// </summary>
-        public class M : QSimM
+        public class M : Microsoft.Quantum.Intrinsic.M
         {
             /// <summary>
             /// The probability with which the error will be introduced before measurement.


### PR DESCRIPTION
See https://github.com/microsoft/qsharp-runtime/pull/476

This is required to unblock the PR above. The `QSimM` class is gone, so directly overriding the intrinsic method is now correct. That still works with the current simulator design, so this change should be safe to merge even before the above goes into qsharp-runtime main branch.