### PR TITLE
Disable documentation generation in samples.

### DIFF
--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -16,8 +16,7 @@ function Build-One {
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
-        /property:Version=$Env:ASSEMBLY_VERSION `
-        /property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR
+        /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to build $project."


### PR DESCRIPTION
This PR disables documentation generation in the samples repo entirely. Since the Microsoft.Quantum.Sdk package turns on documentation generation when either `QSharpDocsGeneration` is `true` _or_ when a specific documentation output path is given, setting a path was causing docs generation to turn on.