### PR TITLE
Fix typo in Sudoku sample

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,12 @@ jobs:
           | ForEach-Object {
               Write-Host "::error file=$_::Project file $_ should be in a solution."
             }
+
+        Write-Host "Found $($projectsInSolutions.Count) project files in solutions, and $($projectsNotInSolutions.Count) not correctly added to solutions.";
+        if ($projectsNotInSolutions.Count -gt 0) {
+          exit 1;
+        }
       name: "Ensure that all projects belong to a solution."
       shell: pwsh
+      continue-on-error: false
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check solution and project files"
     steps:
+    - uses: actions/checkout@v2
     - run: |
         $solutions = Get-ChildItem -Recurse *.sln;
         $projectsInSolutions = $solutions `
@@ -35,6 +36,5 @@ jobs:
         }
       name: "Ensure that all projects belong to a solution."
       shell: pwsh
-      working-directory: .
       continue-on-error: false
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  check-solutions:
+    runs-on: ubuntu-latest
+    name: "Check solution and project files"
+    steps:
+    - run: |
+        $projectsInSolutions = Get-ChildItem -Recurse *.sln `
+          | ForEach-Object {
+            $sln = $_;
+            $slnRoot = [IO.Path]::GetDirectoryName($sln);
+            dotnet sln $sln list `
+              | Where-Object {
+                  $_.EndsWith(".csproj") -or $_.EndsWith(".fsproj")
+                } `
+              | ForEach-Object { Join-Path $slnRoot $_ | Get-Item }
+          } `
+          | ForEach-Object { $_.FullName }
+        $projectsNotInSolutions = Get-ChildItem -Recurse *.csproj, *.fsproj `
+          | Where-Object { $_.FullName -notin $projectsInSolutions };
+
+        $projectsNotInSolutions `
+          | ForEach-Object {
+              Write-Host "::error file=$_::Project file $_ should be in a solution."
+            }
+      name: "Ensure that all projects belong to a solution."
+      shell: pwsh
+

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,8 @@ jobs:
     name: "Check solution and project files"
     steps:
     - run: |
-        $projectsInSolutions = Get-ChildItem -Recurse *.sln `
+        $solutions = Get-ChildItem -Recurse *.sln;
+        $projectsInSolutions = $solutions `
           | ForEach-Object {
             $sln = $_;
             $slnRoot = [IO.Path]::GetDirectoryName($sln);
@@ -28,11 +29,12 @@ jobs:
               Write-Host "::error file=$_::Project file $_ should be in a solution."
             }
 
-        Write-Host "Found $($projectsInSolutions.Count) project files in solutions, and $($projectsNotInSolutions.Count) not correctly added to solutions.";
+        Write-Host "Found $($projectsInSolutions.Count) project files in $($solutions.Count) solutions, and $($projectsNotInSolutions.Count) not correctly added to solutions.";
         if ($projectsNotInSolutions.Count -gt 0) {
           exit 1;
         }
       name: "Ensure that all projects belong to a solution."
       shell: pwsh
+      working-directory: .
       continue-on-error: false
 

--- a/samples/algorithms/algorithms.sln
+++ b/samples/algorithms/algorithms.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleGroverSample", "simpl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrderFinding", "order-finding\OrderFinding.csproj", "{E8FA6E29-B0B4-4D27-89A1-119AC69F630A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SudokuGroverSample", "sudoku-grover\SudokuGroverSample.csproj", "{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{E8FA6E29-B0B4-4D27-89A1-119AC69F630A}.Release|x64.Build.0 = Release|Any CPU
 		{E8FA6E29-B0B4-4D27-89A1-119AC69F630A}.Release|x86.ActiveCfg = Release|Any CPU
 		{E8FA6E29-B0B4-4D27-89A1-119AC69F630A}.Release|x86.Build.0 = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x64.Build.0 = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/algorithms/algorithms.sln
+++ b/samples/algorithms/algorithms.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrderFinding", "order-findi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SudokuGroverSample", "sudoku-grover\SudokuGroverSample.csproj", "{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepeatUntilSuccess", "repeat-until-success\RepeatUntilSuccess.csproj", "{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x64.Build.0 = Release|Any CPU
 		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{2F083C44-6A06-4A81-9100-0D63DCD3B4BD}.Release|x86.Build.0 = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|x64.Build.0 = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D9BEA2D-1435-4BB3-9F93-E32616D8CEC8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -161,7 +161,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
         edgeConflictQubits : Qubit[], startingColorConflictQubits : Qubit[], bitsPerColor: Int
     )
     : Unit is Adj + Ctl {
-        for (start, end), conflictQubit) in Zipped(edges, edgeConflictQubits {
+        for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {
             // Check that endpoints of the edge have different colors:
             // apply ColorEqualityOracle_Nbit oracle;
             // if the colors are the same the result will be 1, indicating a conflict
@@ -171,7 +171,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
                 conflictQubit
             );
         }
-        for (cell, value), conflictQubit) in Zipped(startingColorConstraints, startingColorConflictQubits {
+        for ((cell, value), conflictQubit) in Zipped(startingColorConstraints, startingColorConflictQubits) {
             // Check that cell does not clash with starting colors.
             ControlledOnInt(value, X)(
                 colorsRegister[cell * bitsPerColor .. (cell + 1) * bitsPerColor - 1],
@@ -278,7 +278,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
                 Partitioned(ConstantArray(numVertices, bitsPerColor), colorsRegister),
                 vertexColorConflictQubits
             );
-            for color, conflictQubit) in zippedColorAndConfictQubi {
+            for (color, conflictQubit) in zippedColorAndConfictQubit {
                 // Only allow colors from 0 to 8 i.e. if bit #3 = 1, then bits 2..0 must be 000.
                 use tempQubit = Qubit();
                 within {

--- a/samples/error-correction/error-correction.sln
+++ b/samples/error-correction/error-correction.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitFlipCode", "bit-flip-code\BitFlipCode.csproj", "{BC51363D-773C-4AD5-9E46-D6E118D6861A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Syndrome", "syndrome\Syndrome.csproj", "{80FAEF91-F845-421C-8621-6639F322AA2D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,17 @@ Global
 		{BC51363D-773C-4AD5-9E46-D6E118D6861A}.Release|x64.Build.0 = Release|Any CPU
 		{BC51363D-773C-4AD5-9E46-D6E118D6861A}.Release|x86.ActiveCfg = Release|Any CPU
 		{BC51363D-773C-4AD5-9E46-D6E118D6861A}.Release|x86.Build.0 = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|x64.Build.0 = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Debug|x86.Build.0 = Debug|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|x64.ActiveCfg = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|x64.Build.0 = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|x86.ActiveCfg = Release|Any CPU
+		{80FAEF91-F845-421C-8621-6639F322AA2D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/samples/machine-learning/machine-learning.sln
+++ b/samples/machine-learning/machine-learning.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HalfMoons", "half-moons\HalfMoons.csproj", "{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelHalfMoons", "parallel-half-moons\ParallelHalfMoons.csproj", "{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wine", "wine\Wine.csproj", "{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|x64.Build.0 = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Debug|x86.Build.0 = Debug|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|x64.ActiveCfg = Release|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|x64.Build.0 = Release|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|x86.ActiveCfg = Release|Any CPU
+		{29B9ACA1-03DA-4C49-B3A3-D147BDCBF057}.Release|x86.Build.0 = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|x64.Build.0 = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|x64.ActiveCfg = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|x64.Build.0 = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B5DD953-EFEF-4368-B963-1AC49BA2CFFF}.Release|x86.Build.0 = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|x64.Build.0 = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Debug|x86.Build.0 = Debug|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|x64.ActiveCfg = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|x64.Build.0 = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|x86.ActiveCfg = Release|Any CPU
+		{226792EB-A499-46E3-A0EE-2E35E4F3CFFE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/samples/runtime/runtime.sln
+++ b/samples/runtime/runtime.sln
@@ -11,6 +11,20 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimulatorWithOverrides", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleGroverSample", "..\algorithms\simple-grover\SimpleGroverSample.csproj", "{829FBC53-487D-4157-84F6-7DA34F4D13B2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "reversible-simulator-advanced", "reversible-simulator-advanced", "{E1BF652C-8864-44B4-994E-A171C2F529B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "host", "reversible-simulator-advanced\host\host.csproj", "{62512388-7522-4418-B8E2-B7B11E32191F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "simulator", "reversible-simulator-advanced\simulator\simulator.csproj", "{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReversibleSimulator", "reversible-simulator-simple\ReversibleSimulator.csproj", "{5F506E8D-F992-402B-AD0E-CC3245F08B45}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "qpic-simulator", "qpic-simulator", "{4523D4B1-8C5A-4595-B630-A7D38813D924}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "host", "qpic-simulator\host\host.csproj", "{ACF128A4-1EB7-47B7-9C44-24E03D655E14}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "simulator", "qpic-simulator\simulator\simulator.csproj", "{3F729B1F-4856-4AFE-91C4-69254034E464}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,11 +83,77 @@ Global
 		{829FBC53-487D-4157-84F6-7DA34F4D13B2}.Release|x64.Build.0 = Release|Any CPU
 		{829FBC53-487D-4157-84F6-7DA34F4D13B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{829FBC53-487D-4157-84F6-7DA34F4D13B2}.Release|x86.Build.0 = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|x64.Build.0 = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Debug|x86.Build.0 = Debug|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|x64.ActiveCfg = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|x64.Build.0 = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|x86.ActiveCfg = Release|Any CPU
+		{62512388-7522-4418-B8E2-B7B11E32191F}.Release|x86.Build.0 = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|x64.Build.0 = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D}.Release|x86.Build.0 = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|x64.Build.0 = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F506E8D-F992-402B-AD0E-CC3245F08B45}.Release|x86.Build.0 = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|x64.Build.0 = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Debug|x86.Build.0 = Debug|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|x64.ActiveCfg = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|x64.Build.0 = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|x86.ActiveCfg = Release|Any CPU
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14}.Release|x86.Build.0 = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|x64.Build.0 = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F729B1F-4856-4AFE-91C4-69254034E464}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {29052B45-C81F-479F-AF7F-3E28BAA3D43D}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{62512388-7522-4418-B8E2-B7B11E32191F} = {E1BF652C-8864-44B4-994E-A171C2F529B6}
+		{2A5DDE0C-C605-4020-BA0E-E7F4EF2BE29D} = {E1BF652C-8864-44B4-994E-A171C2F529B6}
+		{ACF128A4-1EB7-47B7-9C44-24E03D655E14} = {4523D4B1-8C5A-4595-B630-A7D38813D924}
+		{3F729B1F-4856-4AFE-91C4-69254034E464} = {4523D4B1-8C5A-4595-B630-A7D38813D924}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
As reported offline by @tcNickolas, a minor typo in a recent update to the Sudoku sample was not caught by our CI process as the sample project was incorrectly omitted from the relevant solution file. This PR:

- Fixes the typo.
- Adds the sudoku sample to the relevant sln file.
- Adds a new CI check to ensure all projects belong to at least one solution.

Note that this PR will **fail** as is, since there are other projects that fail the new check. Once CI has run and identified these projects, I will update the PR accordingly.