### PR TITLE
Workaround for QIR generation in e2e builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ __pycache__/
 
 # Common VS Code extensions
 .ionide/symbolCache.db
+
+# Generated QIR .ll files
+**/[Qq]ir/*.ll

--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -33,8 +33,8 @@ function Build-One {
     }
 }
 
-Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' `
-    | ForEach-Object { Build-One $_.FullName }
+# Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' `
+#     | ForEach-Object { Build-One $_.FullName }
 
 # The commented out lines are projects that are not yet compatible for QIR generation.
 $QirProjects = @(
@@ -89,8 +89,16 @@ $QirProjects = @(
     (Join-Path $PSScriptRoot .. samples simulation qaoa QAOA.csproj)
 )
 
+$qirSln = (Join-Path $PSScriptRoot .. QIR.sln)
+dotnet new sln -n QIR -o (Join-Path $PSScriptRoot ..)
+
 $QirProjects `
-    | ForEach-Object { Build-One $_ -generateQir }
+    | ForEach-Object { 
+        dotnet sln $qirSln add $_
+        # Build-One $_ -generateQir
+    }
+Build-One QIR.sln -generateQir
+Remove-Item QIR.sln
 
 if (-not $all_ok) {
     throw "At least one test failed execution. Check the logs."

--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -38,8 +38,8 @@ function Build-One {
     }
 }
 
-# Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' `
-#     | ForEach-Object { Build-One $_.FullName }
+Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' `
+    | ForEach-Object { Build-One $_.FullName }
 
 # The commented out lines are projects that are not yet compatible for QIR generation.
 $QirProjects = @(


### PR DESCRIPTION
Finally landed at a workaround that actually works, as seen in this e2e build: https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=26386&view=results. This will work for the time being and we can refine/update as we adjust the behavior of Qir Generation and libraries going forward.