### PR TITLE
Fixed simple typo in the docs

### DIFF
--- a/binder-index.md
+++ b/binder-index.md
@@ -18,7 +18,7 @@ jupyter:
 
 These samples demonstrate the use of Q# and the Quantum Development Kit for a variety of different quantum computing tasks.
 
-Many samples can be used directly in your browser using either Q# on its own, or Q# togther with Python.
+Many samples can be used directly in your browser using either Q# on its own, or Q# together with Python.
 Alternatively, you can [create a new command line terminal](http://127.0.0.1:8888/terminals/new) to run most Q# standalone samples, as well as samples that demonstrate how to use Q# together with Python or .NET.
 
 A small number of the samples have additional installation requirements beyond those for the rest of the Quantum Development Kit.

--- a/samples/algorithms/chsh-game/host.py
+++ b/samples/algorithms/chsh-game/host.py
@@ -31,7 +31,7 @@ def referee_single_round() -> bool:
     strategy won the round.
     """
     
-    # Generate random inpus for each player.
+    # Generate random inputs for each player.
     alice_input, bob_input = get_random_bits(2)
     
     # Check whether Alice or Bob should go first.


### PR DESCRIPTION
There is a small typo in samples/algorithms/chsh-game/host.py.

Should read `inputs` rather than `inpus` and  `together` instead of `togther`

Fixes #451
