### PR TITLE
Add IonQ cost to Azure Quantum samples

### DIFF
--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -41,7 +41,7 @@ az quantum target list --output table
 ```
 
 > :warning:
-> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $14 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $5 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest
 

--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -40,7 +40,7 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
-> ::warning::
+> :warning:
 > This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $14 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest

--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -40,6 +40,9 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
+> ::warning::
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $14 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+
 ## Manifest
 
 - [Grover.csproj](https://github.com/microsoft/quantum/blob/main/samples/azure-quantum/grover/Grover.csproj): Main Q# project file for this sample.

--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -41,7 +41,7 @@ az quantum target list --output table
 ```
 
 > :warning:
-> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $5 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $6 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest
 

--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -31,7 +31,7 @@ dotnet run -- --simulator QuantumSimulator --n-qubits=3 --idx-marked=6
 Make sure that you have [created and selected a quantum workspace](https://docs.microsoft.com/azure/quantum/how-to-create-quantum-workspaces-with-the-azure-portal), and then run the following at the command line, substituting `TARGET` with the target that you would like to run against (e.g.: `ionq.qpu` or `honeywell.hqs-lt-1.0`):
 
 ```azcli
-az quantum execute --target-id TARGET -- --n-qubits=4 --idx-marked=6
+az quantum execute --target-id TARGET -- --n-qubits=3 --idx-marked=6
 ```
 
 For a full list of available QIO and quantum computing targets, run:

--- a/samples/azure-quantum/hidden-shift/README.md
+++ b/samples/azure-quantum/hidden-shift/README.md
@@ -22,7 +22,7 @@ The program takes one command-line option, `--n-qubits`, to control the number o
 ## Running the sample on a local simulator
 
 ```dotnetcli
-dotnet run -- --simulator QuantumSimulator --pattern-int 6 --register-size 4
+dotnet run -- --simulator QuantumSimulator --pattern-int 6 --register-size 3
 ```
 
 ## Running the sample on Azure Quantum

--- a/samples/azure-quantum/hidden-shift/README.md
+++ b/samples/azure-quantum/hidden-shift/README.md
@@ -39,7 +39,7 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
-> ::warning::
+> :warning:
 > This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $1-$2 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest

--- a/samples/azure-quantum/hidden-shift/README.md
+++ b/samples/azure-quantum/hidden-shift/README.md
@@ -39,6 +39,9 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
+> ::warning::
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $1-$2 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+
 ## Manifest
 
 - [HiddenShift.csproj](https://github.com/microsoft/quantum/blob/main/samples/azure-quantum/hidden-shift/HiddenShift.csproj): Main Q# project file for this sample.

--- a/samples/azure-quantum/ising-model/README.md
+++ b/samples/azure-quantum/ising-model/README.md
@@ -37,7 +37,7 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
-> ::warning::
+> :warning:
 > This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $53 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest

--- a/samples/azure-quantum/ising-model/README.md
+++ b/samples/azure-quantum/ising-model/README.md
@@ -37,6 +37,9 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
+> ::warning::
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $53 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+
 ## Manifest
 
 - [IsingModel.csproj](https://github.com/microsoft/quantum/blob/main/samples/azure-quantum/ising-model/IsingModel.csproj): Main Q# project file for this sample.

--- a/samples/azure-quantum/parallel-qrng/README.md
+++ b/samples/azure-quantum/parallel-qrng/README.md
@@ -78,7 +78,7 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
-> ::warning::
+> :warning:
 > This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $1-$2 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
 
 ## Manifest

--- a/samples/azure-quantum/parallel-qrng/README.md
+++ b/samples/azure-quantum/parallel-qrng/README.md
@@ -78,6 +78,9 @@ For a full list of available QIO and quantum computing targets, run:
 az quantum target list --output table
 ```
 
+> ::warning::
+> This sample makes use of paid services on Azure Quantum. The cost of running this sample *with the provided parameters* on IonQ in a Pay-As-You-Go subscription is approximately $1-$2 USD (or the equivalent amount in your local currency). This quantity is only an approximate estimate and should not be used as a binding reference. The cost of the service might vary depending on your region, demand and other factors.
+
 ## Manifest
 
 - [ParallelQrng.csproj](https://github.com/microsoft/quantum/blob/main/samples/azure-quantum/parallel-qrng/ParallelQrng.csproj): Main Q# project file for this sample.


### PR DESCRIPTION
@KittyYeungQ

Teleportation sample is exclude since it's not compatible with IonQ.

Also update certain sample inputs as follows:
 - grover: `--n-qubits` 4 doesn't run on Honeywell, change to 3 (too many qubits, 7 in total)
 - hidden-shift: `--n-qubits` avoid confusion in regards to which input is used in the cost estimate, simulator (4) or AQ (3), make both 3