### PR TITLE
Upgrade Powershell to 7.1.4

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get -y update && \
 # installed. It tends to be more stable to use the .NET Core SDK to do so than
 # to use the Debian package manager, due to issues with syncing libicu
 # dependencies.
-RUN dotnet tool install --global PowerShell --version 7.1.3
+RUN dotnet tool install --global PowerShell --version 7.1.4
 
 # Install Jupytext to expose Markdown files as Jupyter Notebooks for use with
 # Binder.


### PR DESCRIPTION
Microsoft security recommendations updated to require PowerShell version 7.1.4