### PR TITLE
Add location argument for parallel_qrng sample

### DIFF
--- a/samples/azure-quantum/parallel-qrng/parallel_qrng.py
+++ b/samples/azure-quantum/parallel-qrng/parallel_qrng.py
@@ -20,14 +20,15 @@ if __name__ == "__main__":
     # Submit the operation to an Azure Quantum workspace.
     if len(sys.argv) < 2:
         print(
-            "Please provide the resource ID for your Azure Quantum workspace as a command-line argument.\n" +
-            "E.g.: python parallel_qrng.py /subscriptions/subscription-id/Microsoft.Quantum/Workspaces/your-workspace-name\n" +
-            "You can copy and paste this resource ID from the Quantum Workspace page in the Azure Portal."
+            "Please provide the resource ID and location for your Azure Quantum workspace as a command-line argument.\n" +
+            "E.g.: python parallel_qrng.py /subscriptions/subscription-id/Microsoft.Quantum/Workspaces/your-workspace-name \"West US\"\n" +
+            "You can copy and paste the resource ID and location from the Quantum Workspace page in the Azure Portal."
         )
 
     else:
         resource_id = sys.argv[1]
-        qsharp.azure.connect(resourceId=resource_id)
-        qsharp.azure.target("ionq.simulator" if len(sys.argv) < 3 else sys.argv[2])
+        location = sys.argv[2]
+        qsharp.azure.connect(resourceId=resource_id, location=location)
+        qsharp.azure.target("ionq.simulator" if len(sys.argv) < 4 else sys.argv[3])
         result = qsharp.azure.execute(SampleRandomNumber, nQubits=3, shots=1000, jobName="Generate 3-bit random number")
         print(f'Azure Quantum service execution result: {result}')


### PR DESCRIPTION
In preparation for removal of default location for connecting to Azure Quantum workspace in microsoft/iqsharp#527, we want to add required location to all samples.