### PR TITLE
Remove non-doc doc comments

### DIFF
--- a/samples/algorithms/database-search/DatabaseSearch.qs
+++ b/samples/algorithms/database-search/DatabaseSearch.qs
@@ -11,9 +11,9 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.AmplitudeAmplification;
 
-    //////////////////////////////////////////////////////////////////////////
-    // Introduction //////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
+    //------------------------------------------------------------------------
+    // Introduction
+    //------------------------------------------------------------------------
 
     // This sample will walk through several examples of searching a database
     // of N elements for a particular marked item using just O(1/√N) queries
@@ -41,9 +41,9 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
     // amplification libraries provided with the canon can make this task
     // significantly easier.
 
-    //////////////////////////////////////////////////////////////////////////
-    // Database Search with Manual Oracle Definitions ////////////////////////
-    //////////////////////////////////////////////////////////////////////////
+    //------------------------------------------------------------------------
+    // Database Search with Manual Oracle Definitions
+    //------------------------------------------------------------------------
 
     // For the first example, we start by hard coding an oracle D
     // that always marks only the item k = N - 1 for N = 2^n and for
@@ -333,9 +333,9 @@ namespace Microsoft.Quantum.Samples.DatabaseSearch {
     }
 
 
-    //////////////////////////////////////////////////////////////////////////
-    // Database Search with the Canon ////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
+    //------------------------------------------------------------------------
+    // Database Search with the Canon
+    //------------------------------------------------------------------------
 
     // Our second example makes full use of the amplitude amplification
     // library and other supporting libraries to implement Grover's algorithm

--- a/samples/algorithms/repeat-until-success/VGateRUS.qs
+++ b/samples/algorithms/repeat-until-success/VGateRUS.qs
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.Samples.RepeatUntilSuccess {
         let result = Measure([inputBasis], [target]);
 
         // From version 0.12 it is no longer necessary to release qubits 
-        /// in zero state.
+        // in zero state.
         ResetAll([target, resource, auxiliary]);
         return (success, result, numIter);
     }

--- a/samples/error-correction/syndrome/Syndrome.qs
+++ b/samples/error-correction/syndrome/Syndrome.qs
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Samples.ErrorCorrection.Syndrome {
 
         H(auxiliary);
         // Apply Controlled Pauli operations to data qubits, resulting in a phase kickback 
-        /// on the auxiliary qubit
+        // on the auxiliary qubit
         for (index, basis) in Zipped(qubitIndices, encodingBases) {
             Controlled ApplyPauli([auxiliary], ([basis], [block[index]]));
         }


### PR DESCRIPTION
This removes some doc comments (`///`) which are not meant to be doc comments.