### PR TITLE
Update version of ca-certificates

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -y update && \
     cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
     echo "deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list && \
     apt-get -y update && \
-    apt-get -y install ca-certificates=20210119 && \
+    apt-get -y install ca-certificates=20211016 && \
     mv /etc/apt/sources.list.backup /etc/apt/sources.list && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
Update version of ca-certificates to the latest in order to unblock the Github Action that publishes samples images. This will allow the sample image to be updated according to security requirements.