### PR TITLE
Fix Deutsch Jozsa Noise sample

### DIFF
--- a/samples/algorithms/noisy-dj/Deutsch–Jozsa with Noise.ipynb
+++ b/samples/algorithms/noisy-dj/Deutsch–Jozsa with Noise.ipynb
@@ -139,7 +139,8 @@
    "id": "historical-treasurer",
    "metadata": {},
    "source": [
-    "Next, we need a Q# operation to represent the oracle itself. To do so, we'll consider an oracle representing the function $$\n",
+    "Next, we need a Q# operation to represent the oracle itself. To do so, we'll consider an oracle representing the function\n",
+    "$$\n",
     "    f(x) = \\begin{cases}\n",
     "        1 & x \\in S \\\\\n",
     "        0 & \\text{otherwise}\n",
@@ -511,31 +512,6 @@
    ],
    "source": [
     "qsharp.component_versions()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "gross-bowling",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>Software</th><th>Version</th></tr><tr><td>QuTiP</td><td>4.6.2</td></tr><tr><td>Numpy</td><td>1.19.2</td></tr><tr><td>SciPy</td><td>1.5.2</td></tr><tr><td>matplotlib</td><td>3.3.2</td></tr><tr><td>Cython</td><td>0.29.21</td></tr><tr><td>Number of CPUs</td><td>16</td></tr><tr><td>BLAS Info</td><td>INTEL MKL</td></tr><tr><td>IPython</td><td>7.19.0</td></tr><tr><td>Python</td><td>3.7.6 (default, Jan  8 2020, 20:23:39) [MSC v.1916 64 bit (AMD64)]</td></tr><tr><td>OS</td><td>nt [win32]</td></tr><tr><td colspan='2'>Fri Oct 22 13:23:23 2021 Pacific Daylight Time</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from qutip.ipynbtools import version_table\n",
-    "version_table()"
    ]
   },
   {


### PR DESCRIPTION
- Fix ordering of callable declaration so that it has assignment for pylance. Also moved it above %%qsharp, so that it does not override the variable with None.
- Fixed MathJax block, so that AzNB can render it
- Removed broken version_table at the bottom, since there is upstream bug that breaks when Cython is not installed