### PR TITLE
fix: validator installation instructions

### DIFF
--- a/Chemistry/Schema/README.md
+++ b/Chemistry/Schema/README.md
@@ -6,8 +6,11 @@ This folder contains the definition of the Broombridge schema and a validator to
 
 The validator tool is a Python script `validator.py` that checks given YAML documents against a JSON schema such as the default `broombridge-0.2.schema.json` file in used to define quantum chemistry problems.
 
-To run the tool, ensure that you have either `ruamel_yaml` or [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) installed and that you have the [`jsonschema`](https://python-jsonschema.readthedocs.io/en/latest/) package installed.
-At your favorite command line, run `validator.py` with an instance of the schema to be tested.
+To run the tool, at your favorite command line, first install the prerequisites
+```bash
+pip install -r requirements.txt
+```
+and then run `validator.py` with an instance of the schema to be tested.
 For example:
 
 ```bash

--- a/Chemistry/Schema/requirements.txt
+++ b/Chemistry/Schema/requirements.txt
@@ -1,0 +1,3 @@
+ruamel.yaml
+jsonschema
+click

--- a/Chemistry/Schema/validator.py
+++ b/Chemistry/Schema/validator.py
@@ -44,7 +44,7 @@ def validate(instance, schema):
 
     for instance_path in glob(instance, recursive=True):
         with open(instance_path, 'r') as f:
-            instance_data = yaml.load(f)
+            instance_data = yaml.safe_load(f)
         
         try:
             schema_name = get_schema_name(instance_data)


### PR DESCRIPTION
The installation instructions for the schema validator were incomplete:

 * the click dependency was missing
 * the validator script actually does not work with pyyaml

This commit adds a `requirements.txt` file that can be used to install
the requirements in one line.