### PR TITLE
Use latest base image

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/microsoft/iqsharp/blob/main/images/iqsharp-base/Dockerfile.
 # As per Binder documentation, we choose to use an SHA sum here instead of a
 # tag.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.20.2110171573
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.21.2111177148
 
 # Mark that this Dockerfile is used with the samples repository.
 ENV IQSHARP_HOSTING_ENV=SAMPLES_DOCKERFILE


### PR DESCRIPTION
Update the base image to the version produced by the last release to pick up a new security patch.