### PR TITLE
Use latest Azure Quantum .NET SDK and Newtonsoft.Json packages

### DIFF
--- a/Chemistry/Schema/README.md
+++ b/Chemistry/Schema/README.md
@@ -7,9 +7,11 @@ This folder contains the definition of the Broombridge schema and a validator to
 The validator tool is a Python script `validator.py` that checks given YAML documents against a JSON schema such as the default `broombridge-0.2.schema.json` file in used to define quantum chemistry problems.
 
 To run the tool, at your favorite command line, first install the prerequisites
+
 ```bash
 pip install -r requirements.txt
 ```
+
 and then run `validator.py` with an instance of the schema to be tested.
 For example:
 

--- a/samples/chemistry/LithiumHydrideGUI/LithiumHydrideGUI.csproj
+++ b/samples/chemistry/LithiumHydrideGUI/LithiumHydrideGUI.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/chemistry/MolecularHydrogenGUI/MolecularHydrogenGUI.csproj
+++ b/samples/chemistry/MolecularHydrogenGUI/MolecularHydrogenGUI.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112180703" />
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.21.2112180703" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/simulation/h2/gui/H2SimulationGUI.csproj
+++ b/samples/simulation/h2/gui/H2SimulationGUI.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The `Azure.Quantum.Client` from the `Q# runtime` repo has been updated to use the latest `Newtonsoft.Json` package `13.0.1`.
Some samples had references directly to `Azure.Quantum.Client` or the `Microsoft.Quantum.Simulators` (which uses `Azure.Quantum.Client`) and they were also referencing to an older version of `Newtonsoft.Json`, causing a build failure.

This PR fixes the samples by bumping them to the latest `Newtonsoft.Json` and unblocks https://github.com/microsoft/qsharp-runtime/pull/904

Manual tests of affected projects:
**MolecularHydrogenGUI**
![image](https://user-images.githubusercontent.com/58103249/150603091-87e462ff-0fd6-465d-a61c-092755001fa8.png)

**LithiumHydrideGUI**
![image](https://user-images.githubusercontent.com/58103249/150603376-c6c61962-06dc-4d1a-88a6-c220e7145684.png)

**H2SimulationGUI**
![image](https://user-images.githubusercontent.com/58103249/150603626-96732163-102b-40a1-a58e-73f49cfcf30d.png)

