### PR TITLE
Remove workspace reload from Parallel QNRG sample for notebooks

### DIFF
--- a/samples/azure-quantum/parallel-qrng/ParallelQrng.ipynb
+++ b/samples/azure-quantum/parallel-qrng/ParallelQrng.ipynb
@@ -70,47 +70,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also write your Q# code in .qs files which are in the same folder as the .ipynb notebook. Running `%workspace reload` will recompile all such .qs files and report the list of available Q# operations and functions. In this case, it finds an operation called `SampleRandomNumber` in a namespace called `Microsoft.Quantum.AzureSamples`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/x-qsharp-data": "{\"LastUpdated\":\"2021-06-30T22:58:09.8857808-07:00\",\"IsCompleted\":true,\"Description\":\"Reloading workspace\",\"Subtask\":\"done\"}",
-      "text/plain": [
-       "Reloading workspace: done!"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/x-qsharp-data": "[\"Microsoft.Quantum.Samples.SampleRandomNumber\"]",
-      "text/html": [
-       "<ul><li>Microsoft.Quantum.Samples.SampleRandomNumber</li></ul>"
-      ],
-      "text/plain": [
-       "Microsoft.Quantum.Samples.SampleRandomNumber"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%workspace reload"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Using `%simulate`, you can invoke the built-in Q# functionality to simulate a quantum operation locally and return the result. You can specify any operation that has been defined in the notebook or that has been imported from a .qs file."
    ]
   },


### PR DESCRIPTION
In a standalone notebook, it may not make sense to reload the workspace. Removing from sample.