### PR TITLE
Optimize by removing redundant `list` call (#602)

### DIFF
--- a/Build/check_indents.py
+++ b/Build/check_indents.py
@@ -25,7 +25,7 @@ def check_file(filename : str) -> bool:
     found_tabs = False
 
     with open(filename, 'r') as f:
-        contents = list(f.readlines())
+        contents = f.readlines()
 
     for line in contents:
         # Find the leading whitespace.


### PR DESCRIPTION
closes #602 

Avoid double iteration by removing `list` call on a `list` object.

```diff
-        contents = list(f.readlines())
+        contents = f.readlines()
```