### PR TITLE
Rm redundant .NET6 SDK install

### DIFF
--- a/Build/images/samples/Dockerfile
+++ b/Build/images/samples/Dockerfile
@@ -21,9 +21,6 @@ RUN apt-get -y update && \
                pkg-config \
                libfreetype6-dev \
                libpng-dev \
-               # iqsharp-base currently ships with .NET Core SDK 3.1, but
-               # we need .NET 6.0 to run dotnet-interactive.
-               dotnet-sdk-6.0 \
                # Make sure to use the most up-to-date curl.
                curl && \
     # As per https://github.com/NuGet/Announcements/issues/49,


### PR DESCRIPTION
iqsharp-base now ships with .NET6 SDK:
- https://github.com/microsoft/iqsharp/pull/538
- https://github.com/microsoft/iqsharp/pull/616