### PR TITLE
Adding global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+    "sdk": {
+        "version": "6.0.100",
+        "rollForward": "latestMinor"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Quantum.Sdk": "0.24.210051-beta"
+    }
+}

--- a/samples/algorithms/integer-factorization/README.md
+++ b/samples/algorithms/integer-factorization/README.md
@@ -11,7 +11,7 @@ urlFragment: integer-factorization
 # Integer Factorization Sample
 
 This sample contains Q# code implementing Shor's quantum algorithm for
-factoring integers.  It uses the [sparse simulator](https://docs.microsoft.com/azure/quantum/user-guide/machines/sparse-simulator)
+factoring integers.  It uses the [sparse simulator](https://docs.microsoft.com/azure/quantum/machines/sparse-simulator)
 to simulate the algorithm for instances that require many qubits.
 
 ## Manifest

--- a/samples/getting-started/simulation/LargeSimulation.ipynb
+++ b/samples/getting-started/simulation/LargeSimulation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Simulating quantum programs with large number of qubits\n",
     "\n",
-    "The quantum programs with large number of qubits can be efficiently simulated using the [sparse simulator](https://docs.microsoft.com/azure/quantum/user-guide/machines/sparse-simulator).\n",
+    "The quantum programs with large number of qubits can be efficiently simulated using the [sparse simulator](https://docs.microsoft.com/azure/quantum/machines/sparse-simulator).\n",
     "\n",
     "The sparse simulator is a simulator that utilizes a sparse representation of quantum state vectors, as opposed to the [full state simulator](https://docs.microsoft.com/azure/quantum/user-guide/machines/full-state-simulator). This feature allows the sparse simulator to minimize the memory footprint used to represent quantum states, thus enabling simulations over a larger number of qubits. The sparse simulator is efficient for representing quantum states that are sparse in the computational basis, that is, quantum states for which most of the amplitude coefficients are zero in the computational basis. As such, sparse simulator enables users to explore larger applications than what can be represented using the full state simulator which will waste both memory and time on an exponentially large number of zero-amplitudes.\n",
     "\n",


### PR DESCRIPTION
Changes on .Net 6.0.300 requires that a local global.json includes the version of the Quantum.Sdk otherwise projects that don't have it specified fail compilation, even if there is another global.json in their parent path.