### PR TITLE
Fix wrong circuit reference in commented out code

### DIFF
--- a/samples/azure-quantum/hidden-shift-gallery/hidden-shift.ipynb
+++ b/samples/azure-quantum/hidden-shift-gallery/hidden-shift.ipynb
@@ -1020,7 +1020,7 @@
         "# result = job.result()\n",
         "# # The histogram returned by the results can be sparse, so here we add any of the missing bitstring labels.\n",
         "# counts = {format(n, \"03b\"): 0 for n in range(8)}\n",
-        "# counts.update(result.get_counts(circuit))\n",
+        "# counts.update(result.get_counts(circ))\n",
         "# plot_histogram(counts)"
       ]
     },


### PR DESCRIPTION
Fix a bug in the commented out code of the sample ("circuit" should be => "circ")