### PR TITLE
Optimize Grover's Search Sudoku Sample

### DIFF
--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -124,7 +124,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
         within {
             for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {
                 // Check that endpoints of the edge have different colors:
-                // apply ColorEqualityOracle_Nbit oracle;
+                // apply ApplyColorEqualityOracle oracle;
                 // if the colors are the same the result will be 1, indicating a conflict
                 ApplyColorEqualityOracle(
                     colorsRegister[start * bitsPerColor .. (start + 1) * bitsPerColor - 1],

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -150,7 +150,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ## bitsPerColor
     /// The number of bits per color.
     /// ## nIterations
-    /// An estimate of the maximum iterations needed.
+    /// The number of iterations needed.
     /// ## oracle
     /// The Oracle used to find solution.
     /// ## statePrep

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -30,8 +30,8 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ## register
     /// The register of qubits to be measured.
     operation MeasureColoring (bitsPerColor : Int, register : Qubit[]) : Int[] {
-        let numVertices = Length(register) / bitsPerColor;
-        let colorPartitions = Partitioned(ConstantArray(numVertices - 1, bitsPerColor), register);
+        let nVertices = Length(register) / bitsPerColor;
+        let colorPartitions = Partitioned(ConstantArray(nVertices - 1, bitsPerColor), register);
         return ForEach(MeasureColor, colorPartitions);
     }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// non qubit vertices.
     ///
     /// # Input
-    /// ## numVertices
+    /// ## nVertices
     /// The number of vertices in the graph.
     /// ## bitsPerColor
     /// The bits per color e.g. 2 bits per color allows for 4 colors.
@@ -114,7 +114,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ```
     /// i.e. every vertex is connected to each other.
     operation ApplyVertexColoringOracle (
-        numVertices : Int, 
+        nVertices : Int, 
         bitsPerColor : Int, 
         edges : (Int, Int)[],
         colorsRegister : Qubit[],
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// Using Grover's search to find vertex coloring.
     ///
     /// # Input
-    /// ## numVertices
+    /// ## nVertices
     /// The number of Vertices in the graph.
     /// ## bitsPerColor
     /// The number of bits per color.
@@ -154,23 +154,21 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ## oracle
     /// The Oracle used to find solution.
     /// ## statePrep
-    /// Routine that prepares an equal superposition of all basis states in the search space.
+    /// An operation that prepares an equal superposition of all basis states in the search space.
     ///
     /// # Output
-    /// Int Array giving the color of each vertex.
-    ///
+    /// An array giving the color of each vertex.
     operation FindColorsWithGrover(
-        numVertices : Int, bitsPerColor : Int, nIterations : Int,
+        nVertices : Int, bitsPerColor : Int, nIterations : Int,
         oracle : ((Qubit[], Qubit) => Unit is Adj),
         statePrep : (Qubit[] => Unit is Adj)) : Int[] {
 
         // Note that coloring register has the number of qubits that is
         // twice the number of vertices (bitsPerColor qubits per vertex).
-        use register = Qubit[bitsPerColor * numVertices];
+        use register = Qubit[bitsPerColor * nVertices];
 
         Message($"Trying search with {nIterations} iterations...");
         ApplyGroversAlgorithmLoop(register, oracle, statePrep, nIterations);
-        let res = MultiM(register);
         let coloring = MeasureColoring(bitsPerColor, register);
         ResetAll(register);
 
@@ -216,7 +214,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ## iterations
     /// The number of iterations to try.
     ///
-    /// # Output
+    /// # Remarks
     /// Unitary implementing Grover's search algorithm.
     operation ApplyGroversAlgorithmLoop(
         register : Qubit[],

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -72,7 +72,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// the same color.
     ///
     /// # Output
-    /// An marking oracle that with the purpose of marking states as allowed where the colors of qubits related by an edge constraints are not equal.
+    /// An marking oracle that marks as allowed those states in which the colors of qubits related by an edge constraint are not equal.
     ///
     ///
     /// # Example

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -113,202 +113,32 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     ///  1---2
     /// ```
     /// i.e. every vertex is connected to each other.
-    /// Additionally, we require that:
-    ///
-    ///    - vertices 0 and 1 do not get colors 2 and 3.
-    ///    - vertices 2 and 3 do not get colors 3 and 0.
-    ///    - vertices 0 and 2 do not get colors 1 and 3.
-    ///    - vertices 1 and 3 do not get colors 2 and 0.
-    /// This results in edges (vertices that can not be same color):
-    /// `edges = [(1, 0),(2, 0),(3, 0),(3, 1),(3, 2)]`
-    /// This is saying that vertex 1 can not have same color as vertex 0 etc.
-    /// and startingColorConstraints = [(0, 1),(0, 3),(0, 2),(1, 2),(1, 0),
-    ///                    (1, 3),(2, 1),(2, 3),(2, 0),(3, 2),(3, 0),(3, 1)]
-    /// This is saying that vertex 0 is not allowed to have values 1,3,2
-    /// and vertex 1 is not allowed to have values 2,0,3
-    /// and vertex 2 is not allowed to have values 1,3,0
-    /// and vertex 3 is not allowed to have values 2,0,1
-    /// A valid graph coloring solution is: [0,1,2,3]
-    /// i.e. vertex 0 has color 0, vertex 1 has color 1 etc.
     operation ApplyVertexColoringOracle (
-        numVertices : Int, bitsPerColor : Int, edges : (Int, Int)[],
-        startingColorConstraints : (Int, Int)[],
+        numVertices : Int, 
+        bitsPerColor : Int, 
+        edges : (Int, Int)[],
         colorsRegister : Qubit[],
         target : Qubit
     )
     : Unit is Adj + Ctl {
         let nEdges = Length(edges);
-        let nStartingColorConstraints = Length(startingColorConstraints);
-        // we are looking for a solution that:
-        // (a) has no edge with same color at both ends and
-        // (b) has no Vertex with a color that violates the starting color constraints.
+        // we are looking for a solution that has no Vertex with a color that violates the starting color constraints.
         use edgeConflictQubits = Qubit[nEdges];
-        use startingColorConflictQubits = Qubit[nStartingColorConstraints];
         within {
-            ConstrainByEdgeAndStartingColors(
-                colorsRegister, edges, startingColorConstraints,
-                edgeConflictQubits, startingColorConflictQubits, bitsPerColor
-            );
-        } apply {
-            // If there are no conflicts (all qubits are in 0 state), the vertex coloring is valid.
-            ControlledOnInt(0, X)(edgeConflictQubits + startingColorConflictQubits, target);
-        }
-    }
-
-    operation ConstrainByEdgeAndStartingColors(
-        colorsRegister : Qubit[], edges : (Int, Int)[],
-        startingColorConstraints : (Int, Int)[],
-        edgeConflictQubits : Qubit[], startingColorConflictQubits : Qubit[], bitsPerColor: Int
-    )
-    : Unit is Adj + Ctl {
-        for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {
-            // Check that endpoints of the edge have different colors:
-            // apply ColorEqualityOracle_Nbit oracle;
-            // if the colors are the same the result will be 1, indicating a conflict
-            ApplyColorEqualityOracle(
-                colorsRegister[start * bitsPerColor .. (start + 1) * bitsPerColor - 1],
-                colorsRegister[end * bitsPerColor .. (end + 1) * bitsPerColor - 1],
-                conflictQubit
-            );
-        }
-        for ((cell, value), conflictQubit) in Zipped(startingColorConstraints, startingColorConflictQubits) {
-            // Check that cell does not clash with starting colors.
-            ControlledOnInt(value, X)(
-                colorsRegister[cell * bitsPerColor .. (cell + 1) * bitsPerColor - 1],
-                conflictQubit
-            );
-        }
-
-    }
-
-    /// # Summary
-    /// Oracle for verifying vertex coloring, including color constraints
-    /// from non qubit vertices. This is the same as ApplyVertexColoringOracle,
-    /// but hardcoded to 4 bits per color and restriction that colors are
-    /// limited to 0 to 8.
-    ///
-    /// # Input
-    /// ## numVertices
-    /// The number of vertices in the graph.
-    /// ## edges
-    /// The array of (Vertex#,Vertex#) specifying the Vertices that can not
-    /// be the same color.
-    /// ## startingColorConstraints
-    /// The array of (Vertex#,Color) specifying the disallowed colors for vertices.
-    /// ## colorsRegister
-    /// The color register.
-    /// ## target
-    /// The target of the operation.
-    ///
-    /// # Output
-    /// A unitary operation that applies `oracle` on the target register if the control
-    /// register state corresponds to the bit mask `bits`.
-    ///
-    /// # Example
-    /// Consider the following 9x9 Sudoku puzzle:
-    /// ```
-    ///    -------------------------------------
-    ///    |   | 6 | 2 | 7 | 8 | 3 | 4 | 0 | 1 |
-    ///    -------------------------------------
-    ///    | 8 |   | 1 | 6 | 2 | 4 | 3 | 7 | 5 |
-    ///    -------------------------------------
-    ///    | 7 | 3 | 4 | 5 | 0 | 1 | 8 | 6 | 2 |
-    ///    -------------------------------------
-    ///    | 6 | 8 | 7 | 1 | 5 | 0 | 2 | 4 | 3 |
-    ///    -------------------------------------
-    ///    | 4 | 1 | 5 | 3 | 6 | 2 | 7 | 8 | 0 |
-    ///    -------------------------------------
-    ///    | 0 | 2 | 3 | 4 | 7 | 8 | 1 | 5 | 6 |
-    ///    -------------------------------------
-    ///    | 3 | 5 | 8 | 0 | 1 | 7 | 6 | 2 | 4 |
-    ///    -------------------------------------
-    ///    | 1 | 7 | 6 | 2 | 4 | 5 | 0 | 3 | 8 |
-    ///    -------------------------------------
-    ///    | 2 | 4 | 0 | 8 | 3 | 6 | 5 | 1 | 7 |
-    ///    -------------------------------------
-    /// ```
-    ///  The challenge is to fill the empty squares with numbers 0 to 8
-    ///  that are unique in row, column and the top left 3x3 square
-    ///  This is a graph coloring problem where the colors are 0 to 8
-    ///  and the empty cells are the vertices. The vertices can be defined as
-    /// ```
-    ///     -----------------
-    ///     | 0 |   |   |   | ...
-    ///     -----------------
-    ///     |   | 1 |   |   | ...
-    ///     -----------------
-    ///     |   |   |   |   | ...
-    ///     ...
-    /// ```
-    /// The graph is
-    /// ```
-    ///     0---1
-    /// ```
-    /// Additionally, we also require that
-    ///    - vertex 0 can not have value 6,2,7,8,3,4,0,1 (row constraint)
-    ///                         or value 8,7,6,4,0,3,1,2 (col constraint)
-    ///    - vertex 1 can not value 8,1,6,2,4,3,7,5 (row constraint)
-    ///                    or value 6,3,8,1,2,5,7,4 (col constraint)
-    /// This results in edges (vertices that can not be same color)
-    /// edges = [(1, 0)]
-    /// This is saying that vertex 1 can not have same color as vertex 0
-    /// and startingColorConstraints = [(0, 8),(0, 7),(0, 6),(0, 4),(0, 0),(0, 3),
-    ///     (0, 1),(0, 2),(1, 6),(1, 3),(1, 8),(1, 1),(1, 2),(1, 5),(1, 7),(1, 4)]
-    /// The colors found must be from 0 to 8, which requires 4 bits per color.
-    /// A valid graph coloring solution is: [5,0]
-    /// i.e. vertex 0 has color 5, vertex 1 has color 0.
-    operation ApplyVertexColoringOracle4Bit9Color (numVertices : Int, edges : (Int, Int)[],
-        startingColorConstraints : (Int, Int)[],
-        colorsRegister : Qubit[], target : Qubit) : Unit is Adj+Ctl {
-        let nEdges = Length(edges);
-        let bitsPerColor = 4; // 4 bits per color
-        let nStartingColorConstraints = Length(startingColorConstraints);
-        // we are looking for a solution that:
-        // (a) has no edge with same color at both ends and
-        // (b) has no Vertex with a color that violates the starting color constraints.
-        use edgeConflictQubits = Qubit[nEdges];
-        use startingColorConflictQubits = Qubit[nStartingColorConstraints];
-        use vertexColorConflictQubits = Qubit[numVertices];
-        within {
-            ConstrainByEdgeAndStartingColors(
-                colorsRegister, edges, startingColorConstraints,
-                edgeConflictQubits, startingColorConflictQubits, bitsPerColor
-            );
-            let zippedColorAndConfictQubit = Zipped(
-                Partitioned(ConstantArray(numVertices, bitsPerColor), colorsRegister),
-                vertexColorConflictQubits
-            );
-            for (color, conflictQubit) in zippedColorAndConfictQubit {
-                // Only allow colors from 0 to 8 i.e. if bit #3 = 1, then bits 2..0 must be 000.
-                use tempQubit = Qubit();
-                within {
-                    ApplyOrOracle(color[0 .. 2], tempQubit);
-                } apply{
-                    // AND color's most significant bit with OR of least significant bits.
-                    // This will set conflictQubit to 1 if color > 8.
-                    CCNOT(color[3], tempQubit, conflictQubit);
-                }
+            for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {
+                // Check that endpoints of the edge have different colors:
+                // apply ColorEqualityOracle_Nbit oracle;
+                // if the colors are the same the result will be 1, indicating a conflict
+                ApplyColorEqualityOracle(
+                    colorsRegister[start * bitsPerColor .. (start + 1) * bitsPerColor - 1],
+                    colorsRegister[end * bitsPerColor .. (end + 1) * bitsPerColor - 1],
+                    conflictQubit
+                );
             }
         } apply {
             // If there are no conflicts (all qubits are in 0 state), the vertex coloring is valid.
-            ControlledOnInt(0, X)(edgeConflictQubits + startingColorConflictQubits + vertexColorConflictQubits, target);
+            ControlledOnInt(0, X)(edgeConflictQubits, target);
         }
-    }
-
-    /// # Summary
-    /// OR oracle for an arbitrary number of qubits in query register.
-    ///
-    /// # Inputs
-    /// ## queryRegister
-    /// Qubit register to query.
-    /// ## target
-    /// Target qubit for storing oracle result.
-    operation ApplyOrOracle (queryRegister : Qubit[], target : Qubit) : Unit is Adj {
-        // x₀ ∨ x₁ = ¬ (¬x₀ ∧ ¬x₁)
-        // First, flip target if both qubits are in |0⟩ state.
-        ControlledOnInt(0, X)(queryRegister, target);
-        // Then flip target again to get negation.
-        X(target);
     }
 
     /// # Summary
@@ -319,51 +149,30 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// The number of Vertices in the graph.
     /// ## bitsPerColor
     /// The number of bits per color.
-    /// ## maxIterations
+    /// ## nIterations
     /// An estimate of the maximum iterations needed.
     /// ## oracle
     /// The Oracle used to find solution.
+    /// ## statePrep
+    /// Routine that prepares an equal superposition of all basis states in the search space.
     ///
     /// # Output
     /// Int Array giving the color of each vertex.
     ///
-    /// # Remarks
-    /// See https://github.com/microsoft/QuantumKatas/tree/main/SolveSATWithGrover
-    /// for original implementation in SolveSATWithGrover Kata.
-    operation FindColorsWithGrover (numVertices : Int, bitsPerColor : Int, maxIterations : Int,
-        oracle : ((Qubit[], Qubit) => Unit is Adj)) : Int[] {
-        // This task is similar to task 2.2 from SolveSATWithGrover kata,
-        // but the percentage of correct solutions is potentially higher.
-        mutable coloring = new Int[numVertices];
+    operation FindColorsWithGrover(
+        numVertices : Int, bitsPerColor : Int, nIterations : Int,
+        oracle : ((Qubit[], Qubit) => Unit is Adj),
+        statePrep : (Qubit[] => Unit is Adj)) : Int[] {
 
         // Note that coloring register has the number of qubits that is
         // twice the number of vertices (bitsPerColor qubits per vertex).
         use register = Qubit[bitsPerColor * numVertices];
-        use output = Qubit();
 
-        mutable correct = false;
-        mutable iter = 1;
-        // Try for one iteration, if it fails, try again for one more iteration and repeat until maxIterations is reached.
-        repeat {
-            Message($"Trying search with {iter} iterations...");
-            ApplyGroversAlgorithmLoop(register, oracle, iter);
-            let res = MultiM(register);
-            // to check whether the result is correct, apply the oracle to the
-            // register plus auxiliary after measurement.
-            oracle(register, output);
-            if (MResetZ(output) == One) {
-                set correct = true;
-                // Read off coloring.
-                set coloring = MeasureColoring(bitsPerColor, register);
-            }
-            ResetAll(register);
-        } until (correct or iter > maxIterations)
-        fixup {
-            set iter += 1;
-        }
-        if (not correct) {
-            fail "Failed to find a coloring.";
-        }
+        Message($"Trying search with {nIterations} iterations...");
+        ApplyGroversAlgorithmLoop(register, oracle, statePrep, nIterations);
+        let res = MultiM(register);
+        let coloring = MeasureColoring(bitsPerColor, register);
+        ResetAll(register);
 
         return coloring;
     }
@@ -412,16 +221,17 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     operation ApplyGroversAlgorithmLoop(
         register : Qubit[],
         oracle : ((Qubit[], Qubit) => Unit is Adj),
+        statePrep : (Qubit[] => Unit is Adj),
         iterations : Int
     )
     : Unit {
         let applyPhaseOracle = ApplyPhaseOracle(oracle, _);
-        ApplyToEach(H, register);
+        statePrep(register);
 
         for _ in 1 .. iterations {
             applyPhaseOracle(register);
             within {
-                ApplyToEachA(H, register);
+                Adjoint statePrep(register);
                 ApplyToEachA(X, register);
             } apply {
                 Controlled Z(Most(register), Tail(register));

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -60,8 +60,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     }
 
     /// # Summary
-    /// Oracle for verifying vertex coloring, including color constraints from
-    /// non qubit vertices.
+    /// Oracle for verifying vertex coloring
     ///
     /// # Input
     /// ## nVertices
@@ -71,12 +70,10 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// ## edges
     /// The array of (Vertex#,Vertex#) specifying the Vertices that can not be
     /// the same color.
-    /// ## startingColorConstraints
-    /// The array of (Vertex#,Color) specifying the disallowed colors for vertices.
     ///
     /// # Output
-    /// A unitary operation that applies `oracle` on the target register if the control
-    /// register state corresponds to the bit mask `bits`.
+    /// An marking oracle that with the purpose of marking states as allowed where the colors of qubits related by an edge constraints are not equal.
+    ///
     ///
     /// # Example
     /// Consider the following 4x4 Sudoku puzzle
@@ -122,7 +119,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     )
     : Unit is Adj + Ctl {
         let nEdges = Length(edges);
-        // we are looking for a solution that has no Vertex with a color that violates the starting color constraints.
+        // we are looking for a solution that has no edge with same color at both ends and
         use edgeConflictQubits = Qubit[nEdges];
         within {
             for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {
@@ -159,7 +156,9 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// # Output
     /// An array giving the color of each vertex.
     operation FindColorsWithGrover(
-        nVertices : Int, bitsPerColor : Int, nIterations : Int,
+        nVertices : Int, 
+        bitsPerColor : Int, 
+        nIterations : Int,
         oracle : ((Qubit[], Qubit) => Unit is Adj),
         statePrep : (Qubit[] => Unit is Adj)) : Int[] {
 
@@ -171,10 +170,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
             Message($"Warning: This might take a while");
         }
         ApplyGroversAlgorithmLoop(register, oracle, statePrep, nIterations);
-        let coloring = MeasureColoring(bitsPerColor, register);
-        ResetAll(register);
-
-        return coloring;
+        return MeasureColoring(bitsPerColor, register);
     }
 
     /// # Summary

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -167,6 +167,9 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
         use register = Qubit[bitsPerColor * nVertices];
 
         Message($"Trying search with {nIterations} iterations...");
+        if (nIterations > 75) {
+            Message($"Warning: This might take a while");
+        }
         ApplyGroversAlgorithmLoop(register, oracle, statePrep, nIterations);
         let coloring = MeasureColoring(bitsPerColor, register);
         ResetAll(register);

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -163,8 +163,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
         oracle : ((Qubit[], Qubit) => Unit is Adj),
         statePrep : (Qubit[] => Unit is Adj)) : Int[] {
 
-        // Note that coloring register has the number of qubits that is
-        // twice the number of vertices (bitsPerColor qubits per vertex).
+        // Coloring register has bitsPerColor qubits for each vertex
         use register = Qubit[bitsPerColor * nVertices];
 
         Message($"Trying search with {nIterations} iterations...");

--- a/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
+++ b/samples/algorithms/sudoku-grover/ColoringGroverWithConstraints.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     /// The register of qubits to be measured.
     operation MeasureColoring (bitsPerColor : Int, register : Qubit[]) : Int[] {
         let nVertices = Length(register) / bitsPerColor;
-        let colorPartitions = Partitioned(ConstantArray(nVertices - 1, bitsPerColor), register);
+        let colorPartitions = Partitioned([bitsPerColor, size=(nVertices - 1)], register);
         return ForEach(MeasureColor, colorPartitions);
     }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.Samples.ColoringGroverWithConstraints {
     )
     : Unit is Adj + Ctl {
         let nEdges = Length(edges);
-        // we are looking for a solution that has no edge with same color at both ends and
+        // we are looking for a solution that has no edge with same color at both ends
         use edgeConflictQubits = Qubit[nEdges];
         within {
             for ((start, end), conflictQubit) in Zipped(edges, edgeConflictQubits) {

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
         {
             var puzzleToRun = args.Length > 0 ? args[0] : "all";
 
-            // Since a lot of the state in grover's search is 0 the sparse simulator can provide great performance gains
+            // Since a lot of the basis states are not used in the superposition state in Grover's search, 
+            // the sparse simulator can provide great performance gains
             var sim = new SparseSimulator(throwOnReleasingQubitsNotInZeroState: true);
 
             int[,] answer4 = {

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
             var puzzleToRun = args.Length > 0 ? args[0] : "all";
 
             // Since a lot of the basis states are not used in the superposition state in Grover's search, 
-            // the sparse simulator can provide great performance gains
+            // the sparse simulator can provide great performance gains compared to the full state simulator
             var sim = new SparseSimulator(throwOnReleasingQubitsNotInZeroState: true);
 
             int[,] answer4 = {
@@ -110,16 +110,16 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
             }
             if (puzzleToRun == "4x4-12" || puzzleToRun == "all") 
             {
-                // Test 4x4 puzzle with 4 missing numbers with Quantum.
-                int[,] puzzle4_4 = {
+                // Test 4x4 puzzle with 12 missing numbers with Quantum.
+                int[,] puzzle4_12 = {
                     { 0,0,3,0 },
                     { 0,0,0,2 },
                     { 0,0,4,0 },
                     { 0,1,0,0 } };
-                Console.WriteLine("Quantum Solving 4x4 with 4 missing numbers.");
-                ShowGrid(puzzle4_4);
-                bool resultFound = sudokuQuantum.QuantumSolve(puzzle4_4, sim).Result;
-                VerifyAndShowResult(resultFound, puzzle4_4, answer4);
+                Console.WriteLine("Quantum Solving 4x4 with 12 missing numbers.");
+                ShowGrid(puzzle4_12);
+                bool resultFound = sudokuQuantum.QuantumSolve(puzzle4_12, sim).Result;
+                VerifyAndShowResult(resultFound, puzzle4_12, answer4);
             }
             if (puzzleToRun == "9x9-1" || puzzleToRun == "all") 
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
             if (puzzleToRun == "9x9-21" || puzzleToRun == "all") 
             {
                 // Test hard 9x9 puzzle with classical and quantum.
-                int[,] puzzle9 = {
+                int[,] puzzle9_21 = {
                     { 0,7,3, 8,0,0, 5,1,2 },
                     { 9,0,2, 7,0,5, 4,8,6 },
                     { 8,4,5, 0,0,0, 0,0,0 },
@@ -177,17 +177,17 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                     { 4,6,9, 1,2,8, 7,3,5 },
                     { 2,8,7, 3,5,6, 1,4,9 },
                     { 3,5,1, 9,4,7, 6,0,8} };
-                int[,] puzzle9_copy = CopyIntArray(puzzle9);
+                int[,] puzzle9_21_copy = CopyIntArray(puzzle9_21);
 
                 Console.WriteLine("Solving 9x9 with 21 missing numbers using classical computing.");
-                ShowGrid(puzzle9);
-                bool resultFound = sudokuClassic.SolveSudokuClassic(puzzle9);
-                VerifyAndShowResult(resultFound, puzzle9, answer9);
+                ShowGrid(puzzle9_21);
+                bool resultFound = sudokuClassic.SolveSudokuClassic(puzzle9_21);
+                VerifyAndShowResult(resultFound, puzzle9_21, answer9);
 
                 Console.WriteLine("Solving 9x9 with 21 missing numbers using Quantum Computing. Cntrl-C to stop.");
-                ShowGrid(puzzle9_copy);
-                resultFound = sudokuQuantum.QuantumSolve(puzzle9_copy, sim).Result;
-                VerifyAndShowResult(resultFound, puzzle9_copy, answer9);
+                ShowGrid(puzzle9_21_copy);
+                resultFound = sudokuQuantum.QuantumSolve(puzzle9_21_copy, sim).Result;
+                VerifyAndShowResult(resultFound, puzzle9_21_copy, answer9);
             }
             Console.WriteLine("Finished.");
         }

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -179,12 +179,12 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                     { 3,5,1, 9,4,7, 6,0,8} };
                 int[,] puzzle9_copy = CopyIntArray(puzzle9);
 
-                Console.WriteLine("Solving 9x9 with 64 missing numbers using classical computing.");
+                Console.WriteLine("Solving 9x9 with 21 missing numbers using classical computing.");
                 ShowGrid(puzzle9);
                 bool resultFound = sudokuClassic.SolveSudokuClassic(puzzle9);
                 VerifyAndShowResult(resultFound, puzzle9, answer9);
 
-                Console.WriteLine("Solving 9x9 with 64 missing numbers using Quantum Computing. Cntrl-C to stop.");
+                Console.WriteLine("Solving 9x9 with 21 missing numbers using Quantum Computing. Cntrl-C to stop.");
                 ShowGrid(puzzle9_copy);
                 resultFound = sudokuQuantum.QuantumSolve(puzzle9_copy, sim).Result;
                 VerifyAndShowResult(resultFound, puzzle9_copy, answer9);

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                     { 0,1,0,0 } };
                 Console.WriteLine("Quantum Solving 4x4 with 12 missing numbers.");
                 ShowGrid(puzzle4_12);
-                bool resultFound = sudokuQuantum.QuantumSolve(puzzle4_12, sim).Result;
+                var resultFound = sudokuQuantum.QuantumSolve(puzzle4_12, sim).Result;
                 VerifyAndShowResult(resultFound, puzzle4_12, answer4);
             }
             if (puzzleToRun == "9x9-1" || puzzleToRun == "all") 

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -150,19 +150,19 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                 bool resultFound = sudokuQuantum.QuantumSolve(puzzle9_2, sim).Result;
                 VerifyAndShowResult(resultFound, puzzle9_2, answer9);
             }
-            if (puzzleToRun == "9x9-64" || puzzleToRun == "all") 
+            if (puzzleToRun == "9x9-hard" || puzzleToRun == "all") 
             {
                 // Test hard 9x9 puzzle with classical and quantum.
                 int[,] puzzle9 = {
-                    { 0,0,0, 0,0,0, 0,1,2 },
-                    { 0,0,0, 0,3,5, 0,0,0 },
-                    { 0,0,0, 6,0,0, 0,7,0 },
-                    { 7,0,0, 0,0,0, 3,0,0 },
-                    { 0,0,0, 4,0,0, 8,0,0 },
-                    { 1,0,0, 0,0,0, 0,0,0 },
-                    { 0,0,0, 1,2,0, 0,0,0 },
-                    { 0,8,0, 0,0,0, 0,4,0 },
-                    { 0,5,0, 0,0,0, 6,0,0 } };
+                    { 0,7,3, 8,0,0, 5,1,2 },
+                    { 9,0,2, 7,0,5, 4,8,6 },
+                    { 8,4,5, 0,0,0, 0,0,0 },
+                    { 7,0,8, 2,0,1, 3,5,0 },
+                    { 5,2,6, 4,0,3, 8,9,1 },
+                    { 1,3,4, 5,0,0, 0,0,0 },
+                    { 4,6,9, 1,2,8, 7,3,5 },
+                    { 2,8,7, 3,5,6, 1,4,9 },
+                    { 3,5,1, 9,4,7, 6,0,8} };
                 int[,] puzzle9_copy = CopyIntArray(puzzle9);
 
                 Console.WriteLine("Solving 9x9 with 64 missing numbers using classical computing.");

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -107,6 +107,19 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                 bool resultFound = sudokuQuantum.QuantumSolve(puzzle4_4, sim).Result;
                 VerifyAndShowResult(resultFound, puzzle4_4, answer4);
             }
+            if (puzzleToRun == "4x4-12" || puzzleToRun == "all") 
+            {
+                // Test 4x4 puzzle with 4 missing numbers with Quantum.
+                int[,] puzzle4_4 = {
+                    { 0,0,3,0 },
+                    { 0,0,0,2 },
+                    { 0,0,4,0 },
+                    { 0,1,0,0 } };
+                Console.WriteLine("Quantum Solving 4x4 with 4 missing numbers.");
+                ShowGrid(puzzle4_4);
+                bool resultFound = sudokuQuantum.QuantumSolve(puzzle4_4, sim).Result;
+                VerifyAndShowResult(resultFound, puzzle4_4, answer4);
+            }
             if (puzzleToRun == "9x9-1" || puzzleToRun == "all") 
             {
                 // Test 9x9 puzzle with classical and quantum - 1 missing number.
@@ -150,7 +163,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                 bool resultFound = sudokuQuantum.QuantumSolve(puzzle9_2, sim).Result;
                 VerifyAndShowResult(resultFound, puzzle9_2, answer9);
             }
-            if (puzzleToRun == "9x9-hard" || puzzleToRun == "all") 
+            if (puzzleToRun == "9x9-21" || puzzleToRun == "all") 
             {
                 // Test hard 9x9 puzzle with classical and quantum.
                 int[,] puzzle9 = {

--- a/samples/algorithms/sudoku-grover/Program.cs
+++ b/samples/algorithms/sudoku-grover/Program.cs
@@ -4,9 +4,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Simulators;
 
 namespace Microsoft.Quantum.Samples.SudokuGrover
@@ -33,7 +31,8 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
         {
             var puzzleToRun = args.Length > 0 ? args[0] : "all";
 
-            var sim = new QuantumSimulator(throwOnReleasingQubitsNotInZeroState: true);
+            // Since a lot of the state in grover's search is 0 the sparse simulator can provide great performance gains
+            var sim = new SparseSimulator(throwOnReleasingQubitsNotInZeroState: true);
 
             int[,] answer4 = {
                 { 1,2,3,4 },

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         startingNumberConstraints : (Int, Int)[]
     ) : Double[][] {
         mutable amplitudes = [[1.0, size=1 <<< bitsPerColor], size=nVertices];
-        for (cell, _) in startingNumberConstraints {
+        for (cell, value) in startingNumberConstraints {
             set amplitudes w/= cell <- (amplitudes[cell] w/ value <- 0.0);
         }
         return amplitudes;

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -111,14 +111,13 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         startingNumberConstraints: (Int, Int)[]
     )
     : (Bool, Int[]) {
-        // for size = 4x4 grid
+        if (size != 4 and size != 9) {
+            fail $"Cannot set size {size}: only a grid size of 4x4 or 9x9 is supported";
+        }
         let bitsPerColor = size == 9 ? 4 | 2;
         let oracle = ApplyVertexColoringOracle(nVertices, bitsPerColor, emptySquareEdges, _, _);
         let statePrep = PrepareSearchStatesSuperposition(nVertices, bitsPerColor, startingNumberConstraints, _);
         let searchSpaceSize = SearchSpaceSize(nVertices, bitsPerColor, startingNumberConstraints);
-        if (size != 4 and size != 9) {
-            fail $"Cannot set size {size}: only a grid size of 4x4 or 9x9 is supported";
-        }
         let numIterations = NIterations(searchSpaceSize);
         Message($"Running Quantum test with #Vertex = {nVertices}");
         Message($"   Bits Per Color = {bitsPerColor}");

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -150,14 +150,15 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     /// The array of (Vertex#, Color) specifying the disallowed colors for vertices.
     ///
     /// # Output
-    /// A 2D array of amplitudes where the first index is the cell and the second index is the value of a basis state (i.e., value) for the cell
+    /// A 2D array of amplitudes where the first index is the cell and the second index is the value of a basis state (i.e., value) for the cell. =
+    /// Allowed amplitudes will have a value 1.0, disallowed amplitudes 0.0
     function AllowedAmplitudes(
         nVertices : Int,
         bitsPerColor : Int,
         startingNumberConstraints : (Int, Int)[]
     ) : Double[][] {
         mutable amplitudes = [[1.0, size=1 <<< bitsPerColor], size=nVertices];
-        for (cell, value) in startingNumberConstraints {
+        for (cell, _) in startingNumberConstraints {
             set amplitudes w/= cell <- (amplitudes[cell] w/ value <- 0.0);
         }
         return amplitudes;
@@ -195,8 +196,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     }
 
     /// # Summary
-    /// Prepare equal superposition of all basis states that satisfy the constraints
-    /// imposed by the digits already placed in the grid.
+    /// Show the size of the search space, i.e. the number of possible combinations
     ///
     /// # Inputs
     /// ## nVertices

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -176,7 +176,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     /// ## startingNumberConstraints
     /// The array of (Vertex#, Color) specifying the disallowed colors for vertices.
     ///
-    /// # Output
+    /// # Remarks
     /// Creates the search space. Using the allowed amplitudes prepares uniform superposition of all allowed values for each cell
     operation PrepareSearchStatesSuperposition(
         nVertices : Int,

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -186,7 +186,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     /// The array of (Vertex#, Color) specifying the disallowed colors for vertices.
     ///
     /// # Remarks
-    /// Creates the search space. Using the allowed amplitudes prepares uniform superposition of all allowed values for each cell
+    /// Prepares the search space. Using the allowed amplitudes prepares uniform superposition of all allowed values for each cell
     operation PrepareSearchStatesSuperposition(
         nVertices : Int,
         bitsPerColor : Int,

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -214,7 +214,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         startingNumberConstraints : (Int, Int)[]
     ) : Int {
         mutable colorOptions = [1 <<< bitsPerColor, size=nVertices];
-        for (cell, value) in startingNumberConstraints {
+        for (cell, _) in startingNumberConstraints {
             set colorOptions w/= cell <- colorOptions[cell] - 1;
         }
         return Fold(TimesI, 1, colorOptions);

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -157,7 +157,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         bitsPerColor : Int,
         startingNumberConstraints : (Int, Int)[]
     ) : Double[][] {
-        mutable amplitudes = ConstantArray(nVertices, ConstantArray(1 <<< bitsPerColor, 1.0));
+        mutable amplitudes = [[1.0, size=1 <<< bitsPerColor], size=nVertices];
         for (cell, value) in startingNumberConstraints {
             set amplitudes w/= cell <- (amplitudes[cell] w/ value <- 0.0);
         }
@@ -214,7 +214,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         bitsPerColor : Int,
         startingNumberConstraints : (Int, Int)[]
     ) : Int {
-        mutable colorOptions = ConstantArray(nVertices, 1 <<< bitsPerColor);
+        mutable colorOptions = [1 <<< bitsPerColor, size=nVertices];
         for (cell, value) in startingNumberConstraints {
             set colorOptions w/= cell <- colorOptions[cell] - 1;
         }
@@ -234,7 +234,6 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     /// solutions
     function NIterations(searchSpaceSize : Int) : Int {
         let angle = ArcSin(1. / Sqrt(IntAsDouble(searchSpaceSize)));
-        Message($"{searchSpaceSize} -- Sqrt(IntAsDouble(searchSpaceSize)) -- {angle} -- {0.25 * PI() / angle - 0.5}");
         let nIterations = Round(0.25 * PI() / angle - 0.5);
         return nIterations;
     }

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -113,7 +113,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     : (Bool, Int[]) {
         // for size = 4x4 grid
         let bitsPerColor = size == 9 ? 4 | 2;
-        let oracle = ApplyVertexColoringOracle(nVertices, bitsPerColor, startingNumberConstraints, _, _);
+        let oracle = ApplyVertexColoringOracle(nVertices, bitsPerColor, emptySquareEdges, _, _);
         let statePrep = PrepareSearchStatesSuperposition(nVertices, bitsPerColor, startingNumberConstraints, _);
         let searchSpaceSize = SearchSpaceSize(nVertices, bitsPerColor, startingNumberConstraints);
         if (size != 4 and size != 9) {

--- a/samples/algorithms/sudoku-grover/Sudoku.qs
+++ b/samples/algorithms/sudoku-grover/Sudoku.qs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         startingNumberConstraints: (Int, Int)[]
     )
     : (Bool, Int[]) {
-        if (size != 4 and size != 9) {
+        if size != 4 and size != 9 {
             fail $"Cannot set size {size}: only a grid size of 4x4 or 9x9 is supported";
         }
         let bitsPerColor = size == 9 ? 4 | 2;
@@ -119,12 +119,13 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
         let statePrep = PrepareSearchStatesSuperposition(nVertices, bitsPerColor, startingNumberConstraints, _);
         let searchSpaceSize = SearchSpaceSize(nVertices, bitsPerColor, startingNumberConstraints);
         let numIterations = NIterations(searchSpaceSize);
-        Message($"Running Quantum test with #Vertex = {nVertices}");
+        Message($"Running Quantum test with # of vertices = {nVertices}");
         Message($"   Bits Per Color = {bitsPerColor}");
         Message($"   emptySquareEdges = {emptySquareEdges}");
         Message($"   startingNumberConstraints = {startingNumberConstraints}");
         Message($"   Estimated #iterations needed = {numIterations}");
         Message($"   Size of Sudoku grid = {size}x{size}");
+        Message($"   Search space size = {searchSpaceSize}");
         let coloring = FindColorsWithGrover(nVertices, bitsPerColor, numIterations, oracle, statePrep);
 
         Message($"Got Sudoku solution: {coloring}");
@@ -148,6 +149,13 @@ namespace Microsoft.Quantum.Samples.SudokuGrover {
     /// The bit width for number of colors.
     /// ## startingNumberConstraints
     /// The array of (Vertex#, Color) specifying the disallowed colors for vertices.
+    ///
+    /// # Examples
+    /// Consider the case where we have 2 vertices, 2 bits per color, and the constraints (0,1),(0,2),(0,3),(1,2).
+    /// Then we would get the result where all non-disallowed values have a 1.0 amplitude:
+    /// [[1.0, 0.0, 0.0, 0.0], 
+    ///  [1.0, 1.0, 0.0, 1.0]]
+    ///
     ///
     /// # Output
     /// A 2D array of amplitudes where the first index is the cell and the second index is the value of a basis state (i.e., value) for the cell. =

--- a/samples/algorithms/sudoku-grover/SudokuQuantum.cs
+++ b/samples/algorithms/sudoku-grover/SudokuQuantum.cs
@@ -107,9 +107,6 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                                 if (puzzle[iSub, jSub] != 0)
                                     startingNumberConstraints.Add(
                                         (emptyIndex, puzzle[iSub, jSub] - 1));
-                                else if (iSub < i && jSub < j)
-                                    emptySquareEdges.Add(
-                                        (emptyIndex, emptyIndexes[iSub, jSub]));
                             }
                         }
                         for (int ii = 0; ii < size; ii++)

--- a/samples/algorithms/sudoku-grover/SudokuQuantum.cs
+++ b/samples/algorithms/sudoku-grover/SudokuQuantum.cs
@@ -132,11 +132,9 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                         }
                         if (size == 9)
                         { // Invalidate numbers that are illegal on a 9x9 board
-                            foreach (var invalid in Enumerable.Range(9, 16 - 9))
-                            {
+                            for (int invalid = 9; invalid < 16; invalid++)
                                 startingNumberConstraints.Add(
                                     (emptyIndex, invalid));
-                            }
                         }
                     }
                 }

--- a/samples/algorithms/sudoku-grover/SudokuQuantum.cs
+++ b/samples/algorithms/sudoku-grover/SudokuQuantum.cs
@@ -107,6 +107,9 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                                 if (puzzle[iSub, jSub] != 0)
                                     startingNumberConstraints.Add(
                                         (emptyIndex, puzzle[iSub, jSub] - 1));
+                                else if ((iSub < jSub) && (iSub != i) && (jSub != j))
+                                    emptySquareEdges.Add(
+                                       (emptyIndex, emptyIndexes[iSub, jSub]));
                             }
                         }
                         for (int ii = 0; ii < size; ii++)

--- a/samples/algorithms/sudoku-grover/SudokuQuantum.cs
+++ b/samples/algorithms/sudoku-grover/SudokuQuantum.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Quantum.Simulation.Common;
 using Microsoft.Quantum.Simulation.Core;
-using Microsoft.Quantum.Simulation.Simulators;
 
 namespace Microsoft.Quantum.Samples.SudokuGrover
 {
@@ -17,7 +16,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
     /// Code to solve a Sudoku puzzle by transforming it into a graph problem 
     /// and calling the Quantum SolvePuzzle operation to solve it
     /// </summary>
-    class SudokuQuantum 
+    class SudokuQuantum
     {
         /// <summary>
         /// QuantumSolve will call Q# code to solve the Sudoku puzzle and display the solution.
@@ -27,12 +26,12 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
         /// <returns>Returns true if a solution was found</returns>
         public async Task<bool> QuantumSolve(int[,] puzzle, SimulatorBase sim)
         {
-            int size = puzzle.GetLength(0); 
+            int size = puzzle.GetLength(0);
             FindEdgesAndInitialNumberConstraints(
-                puzzle, 
-                size, 
-                out var emptySquareEdges, 
-                out var startingNumberConstraints, 
+                puzzle,
+                size,
+                out var emptySquareEdges,
+                out var startingNumberConstraints,
                 out var emptySquares
             );
             var emptySquareEdgesQArray = new QArray<(long, long)>(emptySquareEdges);
@@ -67,7 +66,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
         /// <param name="emptySquareEdges">The list of empty square edges specifying Vertices in the same row/col/subgrid</param>
         /// <param name="startingNumberConstraints">The set of numbers that this empty square can not have</param>
         /// <param name="emptySquares">List of empty squares with their i,j locations</param>
-        void FindEdgesAndInitialNumberConstraints(int[,] puzzle, int size, 
+        void FindEdgesAndInitialNumberConstraints(int[,] puzzle, int size,
             out List<(long, long)> emptySquareEdges, out HashSet<(long, long)> startingNumberConstraints,
             out List<EmptySquare> emptySquares)
         {
@@ -130,6 +129,14 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                             else if (jj < j)
                                 emptySquareEdges.Add(
                                     (emptyIndex, emptyIndexes[i, jj]));
+                        }
+                        if (size == 9)
+                        { // Invalidate numbers that are illegal on a 9x9 board
+                            for (int invalid = 9; invalid < 16; invalid++)
+                            {
+                                startingNumberConstraints.Add(
+                                    (emptyIndex, invalid));
+                            }
                         }
                     }
                 }

--- a/samples/algorithms/sudoku-grover/SudokuQuantum.cs
+++ b/samples/algorithms/sudoku-grover/SudokuQuantum.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.Samples.SudokuGrover
                         }
                         if (size == 9)
                         { // Invalidate numbers that are illegal on a 9x9 board
-                            for (int invalid = 9; invalid < 16; invalid++)
+                            foreach (var invalid in Enumerable.Range(9, 16 - 9))
                             {
                                 startingNumberConstraints.Add(
                                     (emptyIndex, invalid));


### PR DESCRIPTION
This pull request optimizes the Grover's search Sudoku sample by encoding constraints into search space minimizing required quantum computation and increasing 0 component of state space.

This change allows enables us to also switch over to the sparse simulator ultimately resulting in greatly increased performance. We now have the ability to solve the puzzle [1] on a regular laptop correctly within about 45min requiring 150 iterations, whereas the previous version estimates to require 804 iterations and does not complete in reasonable time.

The difference in [2] is even more significant, the proposed change solves the puzzle instantly with 0 iterations, whereas the current version estimates to require 205887 iterations.

[1]: 
```csharp
{
{ 0,7,3, 8,0,0, 5,1,2 },
{ 9,0,2, 7,0,5, 4,8,6 },
{ 8,4,5, 0,0,0, 0,0,0 },
{ 7,0,8, 2,0,1, 3,5,0 },
{ 5,2,6, 4,0,3, 8,9,1 },
{ 1,3,4, 5,0,0, 0,0,0 },
{ 4,6,9, 1,2,8, 7,3,5 },
{ 2,8,7, 3,5,6, 1,4,9 },
{ 3,5,1, 9,4,7, 6,0,8}
};
```

[2]:

```csharp
{
{ 0,7,3, 8,9,4, 5,1,2 },
{ 9,0,2, 7,3,5, 4,8,6 },
{ 8,4,5, 6,1,2, 9,7,3 },
{ 7,0,8, 2,0,1, 3,5,0 },
{ 5,2,6, 4,0,3, 8,9,1 },
{ 1,3,4, 5,8,9, 0,0,0 },
{ 4,6,9, 1,2,8, 7,3,5 },
{ 2,8,7, 3,5,6, 1,4,9 },
{ 3,5,1, 9,4,7, 6,2,8}
};
```