### PR TITLE
More space saving tricks in CI scripts

### DIFF
--- a/Build/qdk-tools.psm1
+++ b/Build/qdk-tools.psm1
@@ -68,6 +68,12 @@ function Invoke-Project() {
     Write-Verbose "##[info]Running dotnet project at $Path...";
     $commonArgs = Get-CommonDotNetArguments;
     dotnet run --project $Path @commonArgs `-- @AdditionalArgs;
+
+    if ($env:FORCE_CLEANUP -eq "true") {
+        # Force cleanup of generated bin and obj folders for this project.
+        Write-Host "##[info]Cleaning up bin/obj from $(Split-Path $Path -Parent)..."
+        Get-ChildItem -Path (Split-Path $Path -Parent) -Recurse | Where-Object { ($_.name -eq "bin" -or $_.name -eq "obj") -and $_.attributes -eq "Directory" } | Remove-Item -recurse -force
+    }
 }
 
 function Get-CommonDotNetArguments {

--- a/Build/test.ps1
+++ b/Build/test.ps1
@@ -20,6 +20,12 @@ function Test-One {
         Write-Host "##vso[task.logissue type=error;]Failed to test $project"
         $script:all_ok = $False
     }
+
+    if ($env:FORCE_CLEANUP -eq "true") {
+        # Force cleanup of generated bin and obj folders for this project.
+        Write-Host "##[info]Cleaning up bin/obj from $(Split-Path (Join-Path $PSScriptRoot $project) -Parent)..."
+        Get-ChildItem -Path (Split-Path (Join-Path $PSScriptRoot $project) -Parent) -Recurse | Where-Object { ($_.name -eq "bin" -or $_.name -eq "obj") -and $_.attributes -eq "Directory" } | Remove-Item -recurse -force
+    }
 }
 
 function Validate-Integrals {


### PR DESCRIPTION
Recent builds have started to run out of space again, so this change mimics the space saving tricks used during build on the test and tools invocation parts of the CI pipeline.