### PR TITLE
Add key in measure function for cirq+quantinuum

### DIFF
--- a/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
+++ b/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
@@ -152,8 +152,8 @@
     "\n",
     "q0 = cirq.LineQubit(0)\n",
     "circuit = cirq.Circuit(\n",
-    "    cirq.H(q0),               # Apply an H-gate to q0\n",
-    "    cirq.measure(q0, key=\"0\")          # Measure q0\n",
+    "    cirq.H(q0),                # Apply an H-gate to q0\n",
+    "    cirq.measure(q0, key=\"0\")  # Measure q0\n",
     ")\n",
     "circuit"
    ]

--- a/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
+++ b/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
@@ -153,7 +153,7 @@
     "q0 = cirq.LineQubit(0)\n",
     "circuit = cirq.Circuit(\n",
     "    cirq.H(q0),               # Apply an H-gate to q0\n",
-    "    cirq.measure(q0)          # Measure q0\n",
+    "    cirq.measure(q0, key=\"0\")          # Measure q0\n",
     ")\n",
     "circuit"
    ]


### PR DESCRIPTION
With latest cirq 1.0.0, the result when using the QDK is empty if not providing a key in the measure command.