### PR TITLE
Small sample fixes for Azure Hosted Notebooks

### DIFF
--- a/samples/algorithms/noisy-dj/Deutsch–Jozsa with Noise.ipynb
+++ b/samples/algorithms/noisy-dj/Deutsch–Jozsa with Noise.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "In this sample, we'll look at how noise in quantum devices may affect quantum algorithms such as the _Deutsch–Jozsa algorithm_, using the open systems simulator provided with the Quantum Development Kit to test Q# applications against different kinds of noise.\n",
     "\n",
-    "> **💡 TIP:** To learn more about the Deutsch–Jozsa algorithm check out the [**getting-started/simple-algorithms** sample](../../getting-started/simple-algorithms/README.md)."
+    "> **💡 TIP:** To learn more about the Deutsch–Jozsa algorithm check out the [**getting-started/simple-algorithms** sample](https://github.com/microsoft/Quantum/blob/main/samples/getting-started/simple-algorithms/README.md)."
    ]
   },
   {
@@ -406,7 +406,7 @@
     "\n",
     "To learn more about the open systems simulator, check out:\n",
     "\n",
-    "- The [**characterization** samples](../../characterization/).\n",
+    "- The [**characterization** samples](https://github.com/microsoft/Quantum/blob/main/samples/characterization/README.md).\n",
     "- The [section on noisy simulation](https://docs.microsoft.com/azure/quantum/user-guide/machines/noise-simulator) in the Quantum Development Kit documentation.\n",
     "- The [**open-systems-concepts** guide](https://github.com/microsoft/qsharp-runtime/blob/main/documentation/examples/open-systems-concepts.ipynb) provided with the Q# runtime."
    ]

--- a/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
+++ b/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
@@ -150,8 +150,8 @@
     "\n",
     "q0 = cirq.LineQubit(0)\n",
     "circuit = cirq.Circuit(\n",
-    "    cirq.H(q0),               # Apply an H-gate to q0\n",
-    "    cirq.measure(q0)          # Measure q0\n",
+    "    cirq.H(q0),                # Apply an H-gate to q0\n",
+    "    cirq.measure(q0, key=\"0\")  # Measure q0\n",
     ")\n",
     "circuit"
    ]
@@ -306,7 +306,7 @@
    "name": "python3"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.2 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -320,10 +320,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.2"
   },
   "nteract": {
    "version": "nteract-front-end@1.0.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "81794d4967e6c3204c66dcd87b604927b115b27c00565d3d43f05ba2f3a2cb0d"
+   }
   }
  },
  "nbformat": 4,

--- a/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
+++ b/samples/azure-quantum/hello-world/HW-quantinuum-cirq.ipynb
@@ -324,11 +324,6 @@
   },
   "nteract": {
    "version": "nteract-front-end@1.0.0"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "81794d4967e6c3204c66dcd87b604927b115b27c00565d3d43f05ba2f3a2cb0d"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Fixes links to be absolute links so they work from Azure.
- Specifies a key for the cirq measure() command so that measurements are not empty