### PR TITLE
Revert .NET provider package name to Microsoft.Quantum.Providers.Honeywell

### DIFF
--- a/samples/azure-quantum/hello-world/HW-quantinuum-qsharp.ipynb
+++ b/samples/azure-quantum/hello-world/HW-quantinuum-qsharp.ipynb
@@ -262,7 +262,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading package Microsoft.Quantum.Providers.Quantinuum and dependencies...\n",
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
       "Active target is now quantinuum.sim.h1-1sc\n",
       "Submitting GenerateRandomBit to target quantinuum.sim.h1-1sc...\n",
       "Job successfully submitted.\n",


### PR DESCRIPTION
This PR reverts the name of the .NET provider back Microsoft.Quantum.Providers.Honeywell that was changed in #728, since this is an internal code that will be remain with the Honeywell name.