### PR TITLE
update ml wine sample miss rate to match halfmoon

### DIFF
--- a/samples/machine-learning/wine/Host.cs
+++ b/samples/machine-learning/wine/Host.cs
@@ -33,12 +33,13 @@ namespace Microsoft.Quantum.Samples
    
             // After training, we can use the validation data to test the accuracy
             // of our new classifier.
-            var testMisses = await ValidateWineModel.Run(
+            var missRate = await ValidateWineModel.Run(
                 targetMachine,
                 optimizedParameters,
                 optimizedBias
             );
-            System.Console.WriteLine($"Observed {testMisses} misclassifications.");
+
+            System.Console.WriteLine($"Observed {100 * missRate:F2}% misclassifications.");
         }
     }
 

--- a/samples/machine-learning/wine/Training.qs
+++ b/samples/machine-learning/wine/Training.qs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Samples {
+    open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Random;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
@@ -68,7 +69,7 @@ namespace Microsoft.Quantum.Samples {
     operation ValidateWineModel(
         parameters : Double[],
         bias : Double
-    ) : Int {
+    ) : Double {
         // Get the remaining samples to use as validation data.
         let samples = (Datasets.WineData())[143...];
         let tolerance = 0.005;
@@ -80,7 +81,7 @@ namespace Microsoft.Quantum.Samples {
             nMeasurements,
             DefaultSchedule(samples)
         );
-        return results::NMisclassifications;
+        return IntAsDouble(results::NMisclassifications) / IntAsDouble(Length(samples));
     }
 
 }


### PR DESCRIPTION
Updated the .NET host script and the Q# Training script in the ML wine sample to be consistent with both the Half Moon examples and the python host by reporting percent miss rate instead of number of missed classifications