### PR TITLE
Update csx formatter project to use dotnet6.0

### DIFF
--- a/.github/workflows/omnisharp.json
+++ b/.github/workflows/omnisharp.json
@@ -1,6 +1,6 @@
 {
   "script": {
     "enableScriptNuGetReferences": true,
-    "defaultTargetFramework": "net5.0"
+    "defaultTargetFramework": "net6.0"
   }
 }


### PR DESCRIPTION
Upgrade the csx file for CI script to run using dotnet 6 instead of dotnet 5, since dotnet 5 is EOL.

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
