### PR TITLE
Fixing the undesirable dependencies issue for qdk

### DIFF
--- a/samples/interoperability/dotnet/qsharp/qsharp.csproj
+++ b/samples/interoperability/dotnet/qsharp/qsharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/interoperability/python/python-qsharp-interop.ipynb
+++ b/samples/interoperability/python/python-qsharp-interop.ipynb
@@ -386,7 +386,7 @@
       "\n",
       "  <PropertyGroup>\n",
       "    <OutputType>Library</OutputType>\n",
-      "    <TargetFramework>netstandard2.1</TargetFramework>\n",
+      "    <TargetFramework>net6.0</TargetFramework>\n",
       "    <!-- This property tells the qsharp package to automatically load\n",
       "         your project and use it as a workspace. -->\n",
       "    <IQSharpLoadAutomatically>true</IQSharpLoadAutomatically>\n",

--- a/samples/interoperability/python/python.csproj
+++ b/samples/interoperability/python/python.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- This property tells the qsharp package to automatically load
          your project and use it as a workspace. -->
     <IQSharpLoadAutomatically>true</IQSharpLoadAutomatically>

--- a/samples/runtime/qpic-simulator/simulator/simulator.csproj
+++ b/samples/runtime/qpic-simulator/simulator/simulator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.