### PR TITLE
Remove QIO references from the Quantum Samples

### DIFF
--- a/samples/azure-quantum/CONTRIBUTING.md
+++ b/samples/azure-quantum/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Process for contributing notebook samples to the Azure Quantum portal experience
 
-This document focuses on the process for creating samples that will eventually appear in the hosted notebooks sample gallery in the portal. If you are creating a sample for other purposes or means of consumption, then this document might not apply to your scenario. (If you are interested in contributing an optimization notebook sample, please see [the microsoft/qio-samples repository](https://github.com/microsoft/qio-samples)).
+This document focuses on the process for creating samples that will eventually appear in the hosted notebooks sample gallery in the portal. If you are creating a sample for other purposes or means of consumption, then this document might not apply to your scenario.
 
 There are three steps involved in contributing a new sample.
 

--- a/samples/azure-quantum/grover/README.md
+++ b/samples/azure-quantum/grover/README.md
@@ -36,7 +36,7 @@ Make sure that you have [created and selected a quantum workspace](https://docs.
 az quantum execute --target-id TARGET -- --n-qubits=3 --idx-marked=6
 ```
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table

--- a/samples/azure-quantum/hello-world/HW-rigetti-qiskit.ipynb
+++ b/samples/azure-quantum/hello-world/HW-rigetti-qiskit.ipynb
@@ -257,7 +257,7 @@
         }
       },
       "source": [
-        "The job ID can be used to retrieve the results later using the [`get_details` method](https://docs.microsoft.com/azure/quantum/optimization-job-reference#jobdetails) or by viewing it under the **Job management** section of the portal."
+        "The job ID can be used to retrieve the results later using the [`get_job` method](https://learn.microsoft.com/azure/quantum/optimization-workspace#workspaceget_job) or by viewing it under the **Job management** section of the portal."
       ]
     },
     {

--- a/samples/azure-quantum/hidden-shift/README.md
+++ b/samples/azure-quantum/hidden-shift/README.md
@@ -33,7 +33,7 @@ Make sure that you have [created and selected a quantum workspace](https://docs.
 az quantum execute --target-id TARGET -- --pattern-int 6 --register-size 3
 ```
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table

--- a/samples/azure-quantum/hidden-shift/hidden-shift.ipynb
+++ b/samples/azure-quantum/hidden-shift/hidden-shift.ipynb
@@ -466,7 +466,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The job ID can be used to retrieve the results later using the [get_details function](https://docs.microsoft.com/azure/quantum/optimization-job-reference#jobdetails) or by viewing it under the **Job management** section of the portal.\n",
+        "The job ID can be used to retrieve the results later using the [`get_job` method](https://learn.microsoft.com/azure/quantum/optimization-workspace#workspaceget_job) or by viewing it under the **Job management** section of the portal.\n",
         "\n",
         "You can monitor the job status with Qiskit's `job_monitor` function.\n",
         "\n",

--- a/samples/azure-quantum/ising-model/README.md
+++ b/samples/azure-quantum/ising-model/README.md
@@ -31,7 +31,7 @@ Make sure that you have [created and selected a quantum workspace](https://docs.
 az quantum execute --target-id TARGET -- --n-sites=5 --time=5.0 --dt=0.1
 ```
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table

--- a/samples/azure-quantum/parallel-qrng/README.md
+++ b/samples/azure-quantum/parallel-qrng/README.md
@@ -43,7 +43,7 @@ Make sure that you have [created and selected a quantum workspace](https://docs.
 az quantum execute --target-id TARGET -- --n-qubits=4
 ```
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table
@@ -72,7 +72,7 @@ cd parallel-qrng/python-host
 python parallel_qrng.py /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME LOCATION TARGET_ID
 ```
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table

--- a/samples/azure-quantum/teleport/README.md
+++ b/samples/azure-quantum/teleport/README.md
@@ -33,7 +33,7 @@ az quantum execute --target-id TARGET -- --prep-basis PauliX --meas-basis PauliX
 
 > **⚠ NOTE:** In order to run this sample, the target must support comparing measurement results.
 
-For a full list of available QIO and quantum computing targets, run:
+For a full list of available quantum computing targets, run:
 
 ```azcli
 az quantum target list --output table


### PR DESCRIPTION
This PR removes references related to QIO (which has been deprecated) from the Quantum Samples.

Note that the Python SDK API documentation currently has an "optimization-" prefix in the URL:
https://learn.microsoft.com/azure/quantum/optimization-workspace
I'm investigating the cause of it and after fixing the URL, I'll create another PR to update the links to that page.