### PR TITLE
Update Advanced Estimation RE notebook to use azure_quantum API

### DIFF
--- a/samples/azure-quantum/resource-estimation/advanced-estimation.ipynb
+++ b/samples/azure-quantum/resource-estimation/advanced-estimation.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "workspace = Workspace(\n",
-    "    resource_id = \"/\",\n",
+    "    resource_id = \"\",\n",
     "    location = \"\",\n",
     ")"
    ]
@@ -157,10 +157,10 @@
    "source": [
     "params = estimator.make_params(num_items=len(bitwidths) * len(target_params))\n",
     "\n",
-    "for idx, (_, target_param) in enumerate(target_params):\n",
-    "    for jdx, bitwidth in enumerate(bitwidths):\n",
-    "        params.items[idx * len(bitwidths) + jdx].qubit_params = target_param\n",
-    "        params.items[idx * len(bitwidths) + jdx].arguments[\"bitwidth\"] = bitwidth\n",
+    "for i, (_, target_param) in enumerate(target_params):\n",
+    "    for j, bitwidth in enumerate(bitwidths):\n",
+    "        params.items[i * len(bitwidths) + j].qubit_params = target_param\n",
+    "        params.items[i * len(bitwidths) + j].arguments[\"bitwidth\"] = bitwidth\n",
     "\n",
     "job = estimator.submit(EstimateMultiplication, input_params=params)\n",
     "results = job.get_results()"

--- a/samples/azure-quantum/resource-estimation/advanced-estimation.ipynb
+++ b/samples/azure-quantum/resource-estimation/advanced-estimation.ipynb
@@ -8,16 +8,13 @@
     "\n",
     "👋 Hello, this sample will showcase how to perform resource estimation\n",
     "experiments created on top of Azure Quantum Resource Estimator.  The sample will\n",
-    "re-use some of the implementations from the _Estimates with Q#_ notebook.\n",
-    "Please refer to that notebook for more details on the setup and algorithm\n",
-    "implementation.\n",
+    "re-use the quantum multiplication algorithm from the _Estimates with Q#_\n",
+    "notebook. We leverage the `azure_quantum` API to configure and submit resource\n",
+    "estimation jobs.\n",
     "\n",
     "## Setup\n",
     "\n",
-    "Let's connect to the Azure Quantum workspace and select the Azure Quantum\n",
-    "Resource Estimator as target.  We are also importing the\n",
-    "`Microsoft.Quantum.Numerics` package that we will require for our example\n",
-    "algorithm."
+    "Let's import some packages and connect to the Azure Quantum workspace."
    ]
   },
   {
@@ -26,6 +23,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from azure.quantum import Workspace\n",
+    "from azure.quantum.target.microsoft import MicrosoftEstimator, QubitParams\n",
+    "from azure.quantum.target.microsoft.target import MicrosoftEstimatorQubitParams\n",
     "import numpy as np                         # To store experimental data from job results\n",
     "from matplotlib import pyplot as plt       # To plot experimental results\n",
     "from matplotlib.colors import hsv_to_rgb   # To automatically find colors for plots"
@@ -37,10 +37,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import qsharp.azure\n",
-    "targets = qsharp.azure.connect(\n",
-    "    resourceId=\"\",\n",
-    "    location=\"\")"
+    "workspace = Workspace(\n",
+    "    resource_id = \"/\",\n",
+    "    location = \"\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are also importing the `qsharp` Python package to write Q# code in Jupyter\n",
+    "cells, and import the `Microsoft.Quantum.Numerics` package that contains the\n",
+    "multiplication algorithm."
    ]
   },
   {
@@ -49,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qsharp.packages.add(\"Microsoft.Quantum.Numerics\")\n",
-    "qsharp.azure.target(\"microsoft.estimator\")"
+    "import qsharp\n",
+    "qsharp.packages.add(\"Microsoft.Quantum.Numerics\")"
    ]
   },
   {
@@ -98,11 +107,14 @@
     "\n",
     "Next, we are setting up some experiments. Here, we are using two of the six\n",
     "pre-defined qubit parameter models, and one customized model based on the model\n",
-    "`qubit_gate_ns_e3`, in which we change the error rates to $10^{-3.5}$. In your\n",
-    "own experiments, you can change the number of items, and also the parameters.\n",
-    "You may use other pre-defined models or define custom models. You can find more\n",
+    "`qubit_gate_ns_e3` (accessed via the constant `QubitParams.GATE_NS_E3`), in\n",
+    "which we change the error rates to $10^{-3.5} \\approx 0.00032$. In your own\n",
+    "experiments, you can change the number of items, and also the parameters. You\n",
+    "may use other pre-defined models or define custom models. You can find more\n",
     "information about the input parameters in the _Getting Started with Azure\n",
-    "Quantum Resource Estimation_ notebook.\n",
+    "Quantum Resource Estimation_ notebook.  Note that in `target_params` we have\n",
+    "tuples of names and qubit parameters.  We are using the names for the plots when\n",
+    "analyzing the results.\n",
     "\n",
     "Further, we are choosing a list of input parameters to our algorithm, in this\n",
     "case bitwidths that are powers-of-2 ranging from 8 to 64."
@@ -114,12 +126,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_params = [\n",
-    "    (\"Gate-based ns, 10⁻³\", {\"qubitParams\": {\"name\": \"qubit_gate_ns_e3\"}}),\n",
-    "    (\"Gate-based ns, 10⁻³ᐧ⁵\", {\"qubitParams\": {\"name\": \"qubit_gate_ns_e3\", \"oneQubitMeasurementErrorRate\": 0.00032, \"oneQubitGateErrorRate\": 0.00032, \"twoQubitGateErrorRate\": 0.00032, \"tGateErrorRate\": 0.00032}}),\n",
-    "    (\"Gate-based ns, 10⁻⁴\", {\"qubitParams\": {\"name\": \"qubit_gate_ns_e4\"}})\n",
-    "]\n",
+    "estimator = MicrosoftEstimator(workspace=workspace)\n",
     "\n",
+    "target_params = [\n",
+    "    (\"Gate-based ns, 10⁻³\", MicrosoftEstimatorQubitParams(name=QubitParams.GATE_NS_E3)),\n",
+    "    (\"Gate-based ns, 10⁻³ᐧ⁵\", MicrosoftEstimatorQubitParams(name=QubitParams.GATE_NS_E3, one_qubit_measurement_error_rate=0.00032, one_qubit_gate_error_rate=0.00032, two_qubit_gate_error_rate=0.00032, t_gate_error_rate=0.00032)),\n",
+    "    (\"Gate-based ns, 10⁻⁴\", MicrosoftEstimatorQubitParams(name=QubitParams.GATE_NS_E4))\n",
+    "]\n",
     "bitwidths = [8, 16, 32, 64]\n",
     "\n",
     "# This is to access the names of the target parameters\n",
@@ -130,9 +143,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are now submitting a resource estimation job for all combinations of target\n",
-    "parameters and input arguments using the `\"items\"` job parameter, which takes as\n",
-    "value a list of target parameters and operation arguments."
+    "We are now creating a batching job, in which we create all the combination of\n",
+    "target_params and bitwidths.  The bitwidth is assigned by accessing it through\n",
+    "the `arguments` field of the item.  We then submit the job with these items for\n",
+    "the multiplication algorithm and wait for the results."
    ]
   },
   {
@@ -141,9 +155,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "items = [{\"arguments\": [{\"name\": \"bitwidth\", \"value\": bitwidth, \"type\": \"Int\"}], **params} for (_, params) in target_params for bitwidth in bitwidths]\n",
+    "params = estimator.make_params(num_items=len(bitwidths) * len(target_params))\n",
     "\n",
-    "results = qsharp.azure.execute(EstimateMultiplication, jobParams={\"items\": items})"
+    "for idx, (_, target_param) in enumerate(target_params):\n",
+    "    for jdx, bitwidth in enumerate(bitwidths):\n",
+    "        params.items[idx * len(bitwidths) + jdx].qubit_params = target_param\n",
+    "        params.items[idx * len(bitwidths) + jdx].arguments[\"bitwidth\"] = bitwidth\n",
+    "\n",
+    "job = estimator.submit(EstimateMultiplication, input_params=params)\n",
+    "results = job.get_results()"
    ]
   },
   {


### PR DESCRIPTION
The `azure_quantum` API is recommended to use over the IQ# API, since it is general for all input. In this PR, we change the advanced estimation notebook to use this API.